### PR TITLE
Add SECURITY.md, network blocking, AI streaming

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' == '' and '$(FLOW_SHARP_RUNTIME_IDENTIFIER)' != '' and ('$(MSBuildProjectName)' == 'FlowSharp.Web' or '$(MSBuildProjectName)' == 'FlowSharp.Worker')">
+    <RuntimeIdentifier>$(FLOW_SHARP_RUNTIME_IDENTIFIER)</RuntimeIdentifier>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+  </PropertyGroup>
+
+  <!-- Keep local Windows builds from copying every native runtime asset shipped by ONNX/SQLite packages. -->
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' == '' and '$(OS)' == 'Windows_NT' and ('$(MSBuildProjectName)' == 'FlowSharp.Web' or '$(MSBuildProjectName)' == 'FlowSharp.Worker')">
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+  </PropertyGroup>
+</Project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ EXPOSE 8081
 # SDK image for restoring and building
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 ARG BUILD_CONFIGURATION=Release
+ARG RUNTIME_IDENTIFIER=linux-musl-x64
 WORKDIR /src
 
 # Copy csproj files for restoring
@@ -22,29 +23,31 @@ COPY ["src/FlowSharp.Infrastructure/FlowSharp.Infrastructure.csproj", "src/FlowS
 COPY ["src/FlowSharp.Nodes/FlowSharp.Nodes.csproj", "src/FlowSharp.Nodes/"]
 
 # Restore dependencies
-RUN dotnet restore "src/FlowSharp.Web/FlowSharp.Web.csproj"
-RUN dotnet restore "src/FlowSharp.Worker/FlowSharp.Worker.csproj"
+RUN dotnet restore "src/FlowSharp.Web/FlowSharp.Web.csproj" -r $RUNTIME_IDENTIFIER
+RUN dotnet restore "src/FlowSharp.Worker/FlowSharp.Worker.csproj" -r $RUNTIME_IDENTIFIER
 
 # Copy all source files
 COPY . .
 
 # Build Web
 WORKDIR "/src/src/FlowSharp.Web"
-RUN dotnet build "FlowSharp.Web.csproj" -c $BUILD_CONFIGURATION -o /app/build
+RUN dotnet build "FlowSharp.Web.csproj" -c $BUILD_CONFIGURATION -r $RUNTIME_IDENTIFIER --self-contained false -o /app/build
 
 # Build Worker
 WORKDIR "/src/src/FlowSharp.Worker"
-RUN dotnet build "FlowSharp.Worker.csproj" -c $BUILD_CONFIGURATION -o /app/build
+RUN dotnet build "FlowSharp.Worker.csproj" -c $BUILD_CONFIGURATION -r $RUNTIME_IDENTIFIER --self-contained false -o /app/build
 
 # Publish Web stage
 FROM build AS publish-web
+ARG RUNTIME_IDENTIFIER=linux-musl-x64
 WORKDIR "/src/src/FlowSharp.Web"
-RUN dotnet publish "FlowSharp.Web.csproj" -c $BUILD_CONFIGURATION -o /app/publish/web /p:UseAppHost=false
+RUN dotnet publish "FlowSharp.Web.csproj" -c $BUILD_CONFIGURATION -r $RUNTIME_IDENTIFIER --self-contained false -o /app/publish/web /p:UseAppHost=false
 
 # Publish Worker stage
 FROM build AS publish-worker
+ARG RUNTIME_IDENTIFIER=linux-musl-x64
 WORKDIR "/src/src/FlowSharp.Worker"
-RUN dotnet publish "FlowSharp.Worker.csproj" -c $BUILD_CONFIGURATION -o /app/publish/worker /p:UseAppHost=false
+RUN dotnet publish "FlowSharp.Worker.csproj" -c $BUILD_CONFIGURATION -r $RUNTIME_IDENTIFIER --self-contained false -o /app/publish/worker /p:UseAppHost=false
 
 # Final Web target image
 FROM base AS web

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,454 @@
+# Security Guide
+
+This document explains FlowSharp's security-relevant settings and the recommended choices for local, self-hosted, and public deployments.
+
+FlowSharp is a workflow automation platform. Some features intentionally execute user-defined workflows, make outbound HTTP requests, run database queries, and load trusted plugins. Treat access to the admin UI and plugin management as privileged access to the host.
+
+## Quick Checklist
+
+- Set `Security:CredentialEncryptionKey` for both Web and Worker.
+- Change the seeded admin password after first login, or override `Seed:Admin`.
+- Use `HttpNodes:Exposure = "Public"` when the instance accepts untrusted users or public workflow/webhook input.
+- Keep `HttpNodes:Exposure = "Local"` when workflows must call localhost or private network services.
+- Install plugins only from repositories you trust.
+- Put public deployments behind a reverse proxy with TLS, request size limits, and rate limits.
+- Do not expose PostgreSQL or Redis ports to the public internet.
+- Consider `Executions:SaveData = "None"` or `"ErrorsOnly"` if workflow payloads can contain secrets.
+
+## Configuration Reference
+
+Example:
+
+```jsonc
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=postgres;Port=5432;Database=flowsharp_db;Username=flowsharp;Password=<strong-password>"
+  },
+  "Database": {
+    "ApplyMigrationsOnStartup": true
+  },
+  "Redis": {
+    "ConnectionString": "redis:6379,password=<strong-password>"
+  },
+  "Worker": {
+    "RunInWebProcess": false
+  },
+  "Security": {
+    "CredentialEncryptionKey": "<base64-encoded-32-byte-key>"
+  },
+  "Seed": {
+    "Enabled": true,
+    "Admin": {
+      "Email": "admin@example.local",
+      "Password": "<temporary-strong-password>"
+    }
+  },
+  "HttpNodes": {
+    "Exposure": "Local",
+    "BlockPrivateNetworks": false
+  },
+  "Executions": {
+    "SaveData": "ErrorsOnly",
+    "MaxCount": 1000,
+    "MaxAgeDays": 30
+  },
+  "Plugins": {
+    "Path": "plugins",
+    "OfficialMarketplaceUrl": "https://github.com/FlowSharp/plugins"
+  },
+  "Rag": {
+    "DatabaseDirectory": "App_Data/rag"
+  },
+  "AllowedHosts": "flowsharp.example.com"
+}
+```
+
+### `Security:CredentialEncryptionKey`
+
+Required. FlowSharp encrypts credential payloads with AES-GCM. The key must be a base64-encoded 32-byte value and must be identical for the Web and Worker processes.
+
+Generate a key with PowerShell:
+
+```powershell
+[Convert]::ToBase64String((1..32 | ForEach-Object { Get-Random -Minimum 0 -Maximum 256 }))
+```
+
+Operational notes:
+
+- If the key is missing, the application fails at startup.
+- Losing the key makes existing encrypted credentials unreadable.
+- Rotating the key requires decrypting existing credentials with the old key and saving them with the new key.
+- Do not commit production keys to source control. Prefer environment variables, Docker secrets, Kubernetes secrets, or a secret manager.
+
+Local development note:
+
+- The checked-in local `appsettings.json` files may contain the legacy development key value:
+  `sU7uc/MSLu+Aib+HM5nrQXwPifVu+UYwbmu6rfwtYBU=`.
+- This value is the explicit form of the old development fallback key and is kept so existing local credentials remain readable.
+- Do not use this key for shared, staging, or production deployments. Override it with `Security__CredentialEncryptionKey`.
+
+Environment variable form:
+
+```text
+Security__CredentialEncryptionKey=<base64-encoded-32-byte-key>
+```
+
+### `Seed`
+
+`Seed:Enabled` controls role and first-admin seeding. The first admin user is created only when there are no users.
+
+Relevant settings:
+
+```jsonc
+"Seed": {
+  "Enabled": true,
+  "Admin": {
+    "Email": "admin@example.local",
+    "Password": "<temporary-strong-password>"
+  }
+}
+```
+
+Recommendations:
+
+- For a fresh private deployment, use a temporary strong password and change it from the admin/account UI after first login.
+- For a hardened production deployment, set the admin email/password via environment variables or secrets.
+- Once initial roles/users are created, you may set `Seed:Enabled` to `false` if you do not want startup seeding behavior.
+
+Environment variable form:
+
+```text
+Seed__Enabled=true
+Seed__Admin__Email=admin@example.local
+Seed__Admin__Password=<temporary-strong-password>
+```
+
+### `HttpNodes`
+
+HTTP nodes can call external APIs. In public or multi-user deployments, they can also become a path to internal services if not restricted. FlowSharp supports a deployment-mode switch:
+
+```jsonc
+"HttpNodes": {
+  "Exposure": "Local",
+  "BlockPrivateNetworks": false
+}
+```
+
+`Exposure` values:
+
+- `Local`: default. Allows localhost and private network targets. Use this when workflows need to call services on the same machine, Docker network, LAN, Ollama, local APIs, internal databases, or internal tools.
+- `Public`: blocks private and localhost targets for HTTP nodes. Use this when the FlowSharp instance is exposed to users or webhook traffic you do not fully control.
+
+`BlockPrivateNetworks`:
+
+- `false`: normal behavior for `Local`.
+- `true`: always blocks private and localhost targets, even if `Exposure` is `Local`.
+
+When blocking is enabled, HTTP nodes reject:
+
+- `localhost`, `127.0.0.0/8`, `::1`
+- private IPv4 ranges such as `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+- link-local ranges such as `169.254.0.0/16` and IPv6 link-local
+- carrier-grade NAT range `100.64.0.0/10`
+- multicast/reserved ranges
+
+Recommended profiles:
+
+```jsonc
+// Local/self-hosted automation profile
+"HttpNodes": {
+  "Exposure": "Local",
+  "BlockPrivateNetworks": false
+}
+```
+
+```jsonc
+// Public/multi-user profile
+"HttpNodes": {
+  "Exposure": "Public",
+  "BlockPrivateNetworks": false
+}
+```
+
+```jsonc
+// Strict profile
+"HttpNodes": {
+  "Exposure": "Local",
+  "BlockPrivateNetworks": true
+}
+```
+
+### `Executions`
+
+Execution records can contain workflow input, node output, HTTP responses, headers, or business data.
+
+```jsonc
+"Executions": {
+  "SaveData": "All",
+  "MaxCount": 1000,
+  "MaxAgeDays": 30
+}
+```
+
+`SaveData` values:
+
+- `All`: saves node outputs and final workflow output.
+- `ErrorsOnly`: saves output data only for failed executions.
+- `None`: saves metadata only; output arrays are empty.
+
+Recommendations:
+
+- Use `All` for local development and debugging.
+- Use `ErrorsOnly` for most self-hosted production installs.
+- Use `None` when workflows process secrets, credentials, personal data, or regulated data.
+- Keep `MaxCount` and `MaxAgeDays` bounded to limit stored sensitive history.
+
+### `Plugins`
+
+Plugins are compiled with Roslyn and loaded into the application process. A plugin can run trusted .NET code in-process.
+
+```jsonc
+"Plugins": {
+  "Path": "plugins",
+  "OfficialMarketplaceUrl": "https://github.com/FlowSharp/plugins"
+}
+```
+
+Recommendations:
+
+- Grant `plugins.manage` only to trusted administrators.
+- Install plugins only from repositories you trust and control.
+- Prefer a private/approved plugin repository in `OfficialMarketplaceUrl`.
+- Review plugin source before installation.
+- Treat plugin installation as equivalent to deploying server-side code.
+
+### `Webhooks`
+
+Webhook workflows are exposed at:
+
+```text
+/webhook/{path}
+```
+
+FlowSharp matches requests by the webhook node's method and path. Runtime exceptions are logged server-side and callers receive a generic error message.
+
+Recommendations:
+
+- Use long, unguessable webhook paths when exposing endpoints publicly.
+- Put public webhook endpoints behind a reverse proxy or API gateway for TLS, rate limiting, request size limits, IP allowlists, and optional authentication.
+- Avoid echoing secrets in `Respond to Webhook` output.
+- Be careful when webhook payloads flow into HTTP, database, AI, or code nodes.
+
+### `ConnectionStrings:DefaultConnection`
+
+PostgreSQL stores users, workflows, queued jobs, encrypted credentials, webhook registrations, and execution records.
+
+Recommendations:
+
+- Use a dedicated database user with the minimum permissions FlowSharp needs.
+- Use a strong password.
+- Do not expose PostgreSQL directly to the internet.
+- Enable TLS between app and database if crossing hosts or networks you do not fully control.
+- Back up the database together with the credential encryption key.
+
+### `Redis:ConnectionString`
+
+Redis is used for cross-process workflow event publication. If Redis is unavailable, FlowSharp falls back to in-memory events.
+
+Recommendations:
+
+- Do not expose Redis directly to the internet.
+- Use Redis authentication when available.
+- Use TLS or a private network for Redis traffic in production.
+- If running Web and Worker separately, Redis improves live execution event delivery across processes.
+
+### `Database:ApplyMigrationsOnStartup`
+
+When `true`, FlowSharp applies EF Core migrations at startup.
+
+Recommendations:
+
+- Convenient for local and small self-hosted deployments.
+- For controlled production releases, prefer applying migrations as a deployment step before starting the app.
+- Avoid running multiple app instances that may try to migrate at the same time unless your deployment process accounts for it.
+
+### `Worker:RunInWebProcess`
+
+When `true`, queued workflow jobs and schedules run inside the Web process.
+
+Recommendations:
+
+- Use `true` for simple local/single-process installs.
+- Use `false` with a separate Worker for production or heavier workloads.
+- Ensure Web and Worker share the same `Security:CredentialEncryptionKey`, database, Redis, and relevant node settings.
+
+### `Rag:DatabaseDirectory`
+
+RAG vector data is stored in SQLite files under this directory.
+
+Recommendations:
+
+- Store it on persistent storage if RAG data must survive restarts.
+- Restrict filesystem permissions to the application identity.
+- Treat RAG data as potentially sensitive if inserted workflow content contains private text.
+
+### `AllowedHosts`
+
+ASP.NET Core uses `AllowedHosts` for host filtering.
+
+Recommendations:
+
+- Use a specific hostname in production, for example `flowsharp.example.com`.
+- Avoid `*` for internet-facing deployments unless the reverse proxy fully controls host routing.
+
+### `ASPNETCORE_ENVIRONMENT` and Detailed Errors
+
+Production deployments should run with:
+
+```text
+ASPNETCORE_ENVIRONMENT=Production
+```
+
+Recommendations:
+
+- Do not run internet-facing deployments with `Development`.
+- Keep `DetailedErrors` disabled outside local development.
+- Production mode enables the production exception handler and HSTS path in the Web app.
+
+### Logging
+
+FlowSharp uses Serilog console and rolling file logs.
+
+Recommendations:
+
+- Protect the `logs` directory.
+- Avoid logging secrets from custom nodes and plugins.
+- Keep `Microsoft.EntityFrameworkCore.Database.Command` at `Warning` or higher unless debugging, because SQL logging can reveal data.
+- Forward production logs to a secured log system with retention policies.
+
+### Docker and Network Exposure
+
+The sample `docker-compose.yml` is convenient for local self-hosting. Review it before internet-facing deployment.
+
+Recommendations:
+
+- Do not publish PostgreSQL port `5432` or Redis port `6379` to public interfaces.
+- Replace sample database passwords.
+- Provide `Security__CredentialEncryptionKey` through secrets or environment variables.
+- Put Web behind a TLS reverse proxy.
+- Persist plugin, log, database, and RAG volumes intentionally.
+
+## Roles and Permissions
+
+FlowSharp seeds three roles:
+
+| Role | Intended access |
+| --- | --- |
+| Admin | Full access, including plugin management. |
+| Editor | Workflow read/write/execute and execution read. |
+| Viewer | Workflow read and execution read. |
+
+Permission names:
+
+| Permission | Purpose |
+| --- | --- |
+| `workflows.read` | View workflows. |
+| `workflows.write` | Create, edit, and delete workflows. |
+| `workflows.execute` | Run workflows. |
+| `executions.read` | View execution history. |
+| `plugins.manage` | Install, reload, and remove plugins. |
+
+Important notes:
+
+- `plugins.manage` is highly privileged because plugins run trusted server-side code.
+- `workflows.write` is powerful because workflows can call external services, database nodes, code nodes, and AI tools.
+- `workflows.execute` is powerful when existing workflows contain sensitive credentials or side effects.
+
+## Node-Specific Security Notes
+
+### HTTP Nodes
+
+HTTP nodes use the `HttpNodes` security mode described above. Public deployments should normally use `Exposure = "Public"`.
+
+### Code Node
+
+The JavaScript code node runs with Jint limits for timeout, memory, and statement count. It is still user-supplied code and should be available only to trusted workflow editors.
+
+### Database Nodes
+
+Database nodes use stored credentials. Use database accounts scoped to the minimum required schema and operation.
+
+### AI Nodes
+
+AI nodes may send prompt content and workflow data to model providers configured by credentials. Do not pass secrets or regulated data to external providers unless that is acceptable for your deployment.
+
+### Spreadsheet, XML, and Data Nodes
+
+File and parser nodes can process user-provided content. Use reverse proxy request limits and keep execution retention bounded if files may contain sensitive data.
+
+## Public Deployment Baseline
+
+For an internet-facing instance, start from this posture:
+
+```jsonc
+{
+  "HttpNodes": {
+    "Exposure": "Public",
+    "BlockPrivateNetworks": false
+  },
+  "Executions": {
+    "SaveData": "ErrorsOnly",
+    "MaxCount": 500,
+    "MaxAgeDays": 14
+  },
+  "Database": {
+    "ApplyMigrationsOnStartup": false
+  },
+  "Seed": {
+    "Enabled": false
+  },
+  "AllowedHosts": "flowsharp.example.com"
+}
+```
+
+Also configure:
+
+- `Security__CredentialEncryptionKey` as a secret.
+- Strong database and Redis credentials.
+- TLS at the reverse proxy.
+- Rate limits for `/webhook/*` and login endpoints.
+- Request body size limits.
+- Backups for database and encryption key.
+
+## Local Automation Baseline
+
+For a personal/self-hosted instance that needs localhost and LAN integrations:
+
+```jsonc
+{
+  "HttpNodes": {
+    "Exposure": "Local",
+    "BlockPrivateNetworks": false
+  },
+  "Executions": {
+    "SaveData": "All",
+    "MaxCount": 1000,
+    "MaxAgeDays": 30
+  },
+  "Worker": {
+    "RunInWebProcess": true
+  }
+}
+```
+
+Use firewall rules or reverse proxy authentication if the instance is reachable from other machines.
+
+## Reporting Security Issues
+
+Do not open public issues for suspected vulnerabilities. Report privately to the project maintainers or the organization operating your FlowSharp instance. Include:
+
+- Affected version or commit.
+- Deployment mode and relevant security settings.
+- Steps to reproduce.
+- Expected and actual impact.
+- Logs or screenshots with secrets removed.

--- a/src/FlowSharp.Application/Nodes/Agents/IAgentExecutor.cs
+++ b/src/FlowSharp.Application/Nodes/Agents/IAgentExecutor.cs
@@ -1,10 +1,11 @@
 using System.Text.Json.Nodes;
 using FlowSharp.Domain.Nodes;
+using FlowSharp.Application.Workflows;
 
 namespace FlowSharp.Application.Nodes.Agents;
 
 /// <summary>Bir AI agent'a bagli alt-node (Model / Tool / Memory).</summary>
-public sealed record AgentSubNode(string Type, string Name, JsonObject Parameters, NodePortType PortType);
+public sealed record AgentSubNode(string Id, string Type, string Name, JsonObject Parameters, NodePortType PortType);
 
 /// <summary>
 /// Verilen node icin bir yurutme baglami uretir. Motor bunu saglar; boylece agent executor
@@ -20,7 +21,9 @@ public sealed record AgentRequest(
     JsonObject AgentParameters,
     IReadOnlyList<NodeItem> Input,
     IReadOnlyList<AgentSubNode> Subs,
-    AgentContextFactory ContextFactory);
+    AgentContextFactory ContextFactory,
+    Func<NodeRunData, Task>? OnSubNodeCompleted = null,
+    Func<string, Task>? OnTextDelta = null);
 
 /// <summary>AI agent calistirma sonucu.</summary>
 public sealed record AgentResult(bool Succeeded, NodeItem Item, string? Error)

--- a/src/FlowSharp.Application/Workflows/IWorkflowExecutionEngine.cs
+++ b/src/FlowSharp.Application/Workflows/IWorkflowExecutionEngine.cs
@@ -24,6 +24,9 @@ public sealed class WorkflowExecutionOptions
     /// <summary>Her node tamamlandiginda cagrilir (SignalR canli durum icin).</summary>
     public Func<NodeRunData, Task>? OnNodeCompleted { get; init; }
 
+    /// <summary>AI modelinden gelen metin parcalarini canli chat UI'ina aktarmak icin kullanilir.</summary>
+    public Func<string, Task>? OnTextDelta { get; init; }
+
     /// <summary>Calisan workflow'un kimligi (RAG gibi workspace'e ozel kaynaklari izole etmek icin).</summary>
     public Guid? WorkflowId { get; init; }
 }

--- a/src/FlowSharp.Infrastructure/DependencyInjection.cs
+++ b/src/FlowSharp.Infrastructure/DependencyInjection.cs
@@ -24,7 +24,10 @@ public static class DependencyInjection
             ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
 
         services.AddDbContext<ApplicationDbContext>(options => options.UseNpgsql(connectionString));
-        services.AddHttpClient("workflow-nodes");
+        services.Configure<HttpNodeNetworkOptions>(configuration.GetSection(HttpNodeNetworkOptions.SectionName));
+        services.AddTransient<PrivateNetworkBlockingHandler>();
+        services.AddHttpClient("workflow-nodes")
+            .AddHttpMessageHandler<PrivateNetworkBlockingHandler>();
 
         // Kuyruk ve calistirma
         services.AddScoped<IWorkflowQueue, PostgresWorkflowQueue>();

--- a/src/FlowSharp.Infrastructure/Security/CredentialProtector.cs
+++ b/src/FlowSharp.Infrastructure/Security/CredentialProtector.cs
@@ -1,7 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace FlowSharp.Infrastructure.Security;
 
@@ -15,28 +14,25 @@ public interface ICredentialProtector
 
 /// <summary>
 /// AES-GCM tabanli sifreleme. Anahtar yapilandirmadan okunur:
-/// <c>Security:CredentialEncryptionKey</c> (base64, 32 bayt). Ayarlanmazsa
-/// geliştirme icin sabit bir anahtar turetilir (production'da uyari verir).
+/// <c>Security:CredentialEncryptionKey</c> (base64, 32 bayt). Anahtar zorunludur;
+/// Web ve Worker ayni anahtari kullanmalidir.
 /// </summary>
 public sealed class CredentialProtector : ICredentialProtector
 {
     private readonly byte[] key;
 
-    public CredentialProtector(IConfiguration configuration, ILogger<CredentialProtector> logger)
+    public CredentialProtector(IConfiguration configuration)
     {
         var configured = configuration["Security:CredentialEncryptionKey"];
-        if (!string.IsNullOrWhiteSpace(configured))
+        if (string.IsNullOrWhiteSpace(configured))
         {
-            key = Convert.FromBase64String(configured);
-            if (key.Length != 32)
-            {
-                throw new InvalidOperationException("Security:CredentialEncryptionKey base64 cozumlendiginde 32 bayt olmali.");
-            }
+            throw new InvalidOperationException("Security:CredentialEncryptionKey ayari zorunludur ve base64 formatinda 32 baytlik bir anahtar olmalidir.");
         }
-        else
+
+        key = Convert.FromBase64String(configured);
+        if (key.Length != 32)
         {
-            logger.LogWarning("Security:CredentialEncryptionKey ayarlanmamis; gelistirme icin turetilmis sabit anahtar kullaniliyor. Production'da mutlaka ayarlayin.");
-            key = SHA256.HashData(Encoding.UTF8.GetBytes("FlowSharp-dev-credential-key"));
+            throw new InvalidOperationException("Security:CredentialEncryptionKey base64 cozumlendiginde 32 bayt olmali.");
         }
     }
 

--- a/src/FlowSharp.Infrastructure/Security/HttpNodeNetworkOptions.cs
+++ b/src/FlowSharp.Infrastructure/Security/HttpNodeNetworkOptions.cs
@@ -1,0 +1,13 @@
+namespace FlowSharp.Infrastructure.Security;
+
+public sealed class HttpNodeNetworkOptions
+{
+    public const string SectionName = "HttpNodes";
+
+    public string Exposure { get; set; } = "Local";
+
+    public bool BlockPrivateNetworks { get; set; }
+
+    public bool ShouldBlockPrivateNetworks =>
+        BlockPrivateNetworks || Exposure.Equals("Public", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/FlowSharp.Infrastructure/Security/PrivateNetworkBlockingHandler.cs
+++ b/src/FlowSharp.Infrastructure/Security/PrivateNetworkBlockingHandler.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using Microsoft.Extensions.Options;
+
+namespace FlowSharp.Infrastructure.Security;
+
+public sealed class PrivateNetworkBlockingHandler(IOptionsMonitor<HttpNodeNetworkOptions> options) : DelegatingHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (!options.CurrentValue.ShouldBlockPrivateNetworks)
+        {
+            return await base.SendAsync(request, cancellationToken);
+        }
+
+        var uri = request.RequestUri ?? throw new InvalidOperationException("HTTP istegi icin URL gerekli.");
+        await EnsurePublicTargetAsync(uri, cancellationToken);
+        return await base.SendAsync(request, cancellationToken);
+    }
+
+    private static async Task EnsurePublicTargetAsync(Uri uri, CancellationToken cancellationToken)
+    {
+        if (!uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+            !uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Public modda yalniz HTTP ve HTTPS hedefleri desteklenir.");
+        }
+
+        var host = uri.Host.Trim('[', ']');
+        if (IPAddress.TryParse(host, out var literalAddress))
+        {
+            ThrowIfPrivate(uri, literalAddress);
+            return;
+        }
+
+        var addresses = await Dns.GetHostAddressesAsync(uri.IdnHost, cancellationToken);
+        if (addresses.Length == 0)
+        {
+            throw new InvalidOperationException($"'{uri.Host}' icin DNS kaydi bulunamadi.");
+        }
+
+        foreach (var address in addresses)
+        {
+            ThrowIfPrivate(uri, address);
+        }
+    }
+
+    private static void ThrowIfPrivate(Uri uri, IPAddress address)
+    {
+        if (IsBlockedAddress(address))
+        {
+            throw new InvalidOperationException($"Public modda private/localhost hedeflerine HTTP istegi engellendi: {uri.Host}");
+        }
+    }
+
+    private static bool IsBlockedAddress(IPAddress address)
+    {
+        if (IPAddress.IsLoopback(address))
+        {
+            return true;
+        }
+
+        if (address.IsIPv4MappedToIPv6)
+        {
+            address = address.MapToIPv4();
+        }
+
+        var bytes = address.GetAddressBytes();
+        return address.AddressFamily switch
+        {
+            System.Net.Sockets.AddressFamily.InterNetwork => IsBlockedIPv4(bytes),
+            System.Net.Sockets.AddressFamily.InterNetworkV6 => IsBlockedIPv6(bytes),
+            _ => true
+        };
+    }
+
+    private static bool IsBlockedIPv4(byte[] bytes)
+    {
+        var first = bytes[0];
+        var second = bytes[1];
+
+        return first switch
+        {
+            0 => true,
+            10 => true,
+            100 when second is >= 64 and <= 127 => true,
+            127 => true,
+            169 when second == 254 => true,
+            172 when second is >= 16 and <= 31 => true,
+            192 when second == 168 => true,
+            >= 224 => true,
+            _ => false
+        };
+    }
+
+    private static bool IsBlockedIPv6(byte[] bytes)
+    {
+        return bytes[0] switch
+        {
+            0xFC or 0xFD => true,
+            0xFE when (bytes[1] & 0xC0) == 0x80 => true,
+            0xFF => true,
+            _ => IsUnspecifiedIPv6(bytes)
+        };
+    }
+
+    private static bool IsUnspecifiedIPv6(byte[] bytes) => bytes.All(b => b == 0);
+}

--- a/src/FlowSharp.Infrastructure/Workflows/WorkflowExecutionEngine.cs
+++ b/src/FlowSharp.Infrastructure/Workflows/WorkflowExecutionEngine.cs
@@ -135,9 +135,22 @@ public sealed class WorkflowExecutionEngine(
                 var agentStartedAt = DateTimeOffset.UtcNow;
                 var request = new AgentRequest(
                     node.Type, node.Name, node.Parameters, input,
-                    subs.Select(s => new AgentSubNode(s.Sub.Type, s.Sub.Name, s.Sub.Parameters, s.Type)).ToList(),
+                    subs.Select(s => new AgentSubNode(s.Sub.Id, s.Sub.Type, s.Sub.Name, s.Sub.Parameters, s.Type)).ToList(),
                     (t, n, p, items) => new NodeExecutionContext(
-                        t, n, p, items, outputsByName, trigger, 0, evaluator, services, _ => { }, cancellationToken, options.WorkflowId));
+                        t, n, p, items, outputsByName, trigger, 0, evaluator, services, _ => { }, cancellationToken, options.WorkflowId),
+                    async data =>
+                    {
+                        if (recordLog)
+                        {
+                            runLog.Add(data);
+                        }
+
+                        if (options.OnNodeCompleted is not null)
+                        {
+                            await options.OnNodeCompleted(data);
+                        }
+                    },
+                    options.OnTextDelta);
 
                 var agentResult = await agentExecutor.ExecuteAsync(request, cancellationToken);
                 run = agentResult.Succeeded

--- a/src/FlowSharp.Nodes/Ai/Agent/SemanticKernelAgentExecutor.cs
+++ b/src/FlowSharp.Nodes/Ai/Agent/SemanticKernelAgentExecutor.cs
@@ -1,10 +1,15 @@
 using System.Text.Json.Nodes;
+using System.Text;
+using System.Net;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
+using FlowSharp.Application.Ai;
 using FlowSharp.Application.Abstractions;
 using FlowSharp.Application.Nodes;
 using FlowSharp.Application.Nodes.Agents;
+using FlowSharp.Application.Workflows;
 using FlowSharp.Nodes.Ai.Models; // AddChatCompletionForProvider
 
 namespace FlowSharp.Nodes.Ai.Agent;
@@ -21,6 +26,9 @@ public sealed class SemanticKernelAgentExecutor(
 {
     public async Task<AgentResult> ExecuteAsync(AgentRequest request, CancellationToken cancellationToken)
     {
+        AgentSubNode? selectedModel = null;
+        var modelStartedAt = DateTimeOffset.UtcNow;
+
         try
         {
             var model = request.Subs.FirstOrDefault(sub => sub.PortType == Domain.Nodes.NodePortType.AiModel);
@@ -29,6 +37,8 @@ public sealed class SemanticKernelAgentExecutor(
                 return AgentResult.Fail("AI Agent bir Model alt-node'una baglanmali.");
             }
 
+            selectedModel = model;
+            modelStartedAt = DateTimeOffset.UtcNow;
             var (provider, credentialType, defaultModel) = GetProviderDetails(model.Type);
             var (apiKey, endpoint, deploymentName) = await ResolveModelCredentialsAsync(model, credentialType, cancellationToken);
 
@@ -58,7 +68,7 @@ public sealed class SemanticKernelAgentExecutor(
 
                 var captured = tool;
                 toolFunctions.Add(KernelFunctionFactory.CreateFromMethod(
-                    (string query) => InvokeToolAsync(captured, query, request.ContextFactory),
+                    (string query) => InvokeToolAsync(request, captured, query, request.ContextFactory),
                     functionName: Sanitize(tool.Name),
                     description: toolType.Definition.Description));
             }
@@ -70,7 +80,8 @@ public sealed class SemanticKernelAgentExecutor(
 
             var agentCtx = request.ContextFactory(request.AgentType, request.AgentName, request.AgentParameters, request.Input);
             var systemPrompt = agentCtx.GetString("systemPrompt") ?? "";
-            var userText = agentCtx.GetString("text") ?? "";
+            var userText = ResolveAgentUserText(agentCtx.GetString("text"), request.Input);
+            var memoryContext = await BuildMemoryContextAsync(request, userText);
 
             var settings = new OpenAIPromptExecutionSettings
             {
@@ -78,36 +89,302 @@ public sealed class SemanticKernelAgentExecutor(
                 Temperature = 0
             };
 
-            var result = await kernel.InvokePromptAsync(
-                $"{systemPrompt}\n\nKullanici: {userText}",
-                new KernelArguments(settings),
-                cancellationToken: cancellationToken);
+            var prompt = string.IsNullOrWhiteSpace(memoryContext)
+                ? $"{systemPrompt}\n\nKullanici: {userText}"
+                : $"{systemPrompt}\n\nBaglam:\n{memoryContext}\n\nKullanici: {userText}";
 
-            return AgentResult.Ok(NodeItem.From(new JsonObject { ["output"] = result.ToString() }));
+            var output = request.OnTextDelta is null
+                ? (await kernel.InvokePromptAsync(
+                    prompt,
+                    new KernelArguments(settings),
+                    cancellationToken: cancellationToken)).ToString()
+                : await InvokePromptStreamingAsync(kernel, prompt, settings, request.OnTextDelta, cancellationToken);
+
+            await NotifySubNodeAsync(request, model, NodeRunStatus.Succeeded, new JsonObject
+            {
+                ["provider"] = provider,
+                ["model"] = modelId
+            }, null, modelStartedAt, 1);
+
+            await SaveConversationMemoryAsync(request, userText, output, cancellationToken);
+
+            return AgentResult.Ok(NodeItem.From(new JsonObject { ["output"] = output }));
         }
         catch (OperationCanceledException)
         {
             throw;
         }
+        catch (HttpOperationException exception)
+        {
+            logger.LogError(exception, "AI Agent '{Name}' model servisi hatasi.", request.AgentName);
+            if (selectedModel is not null)
+            {
+                await NotifySubNodeAsync(request, selectedModel, NodeRunStatus.Failed, new JsonObject(), FormatAiServiceError(exception), modelStartedAt, 0);
+            }
+            return AgentResult.Fail(FormatAiServiceError(exception));
+        }
         catch (Exception exception)
         {
             logger.LogError(exception, "AI Agent '{Name}' hatasi.", request.AgentName);
-            return AgentResult.Fail(exception.Message);
+            if (selectedModel is not null)
+            {
+                await NotifySubNodeAsync(request, selectedModel, NodeRunStatus.Failed, new JsonObject(), "Model cagrisi basarisiz oldu.", modelStartedAt, 0);
+            }
+            return AgentResult.Fail("AI Agent calismasi sirasinda beklenmeyen bir hata olustu. Detaylar loglara yazildi.");
         }
     }
 
-    private async Task<string> InvokeToolAsync(AgentSubNode tool, string query, AgentContextFactory contextFactory)
+    private static string FormatAiServiceError(HttpOperationException exception)
     {
+        var statusCode = exception.StatusCode;
+        return statusCode switch
+        {
+            HttpStatusCode.ServiceUnavailable =>
+                "Model servisi su anda kullanilamiyor (503). Biraz sonra tekrar deneyin veya model/endpoint ayarlarini kontrol edin.",
+            HttpStatusCode.TooManyRequests =>
+                "Model servisi hiz limitine takildi (429). Biraz sonra tekrar deneyin veya kota/limit ayarlarini kontrol edin.",
+            HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden =>
+                $"Model servisi kimlik dogrulamayi reddetti ({(int)statusCode.Value}). API anahtari ve credential ayarlarini kontrol edin.",
+            HttpStatusCode.NotFound =>
+                "Model servisi secilen modeli veya endpoint'i bulamadi (404). Model/deployment adini kontrol edin.",
+            { } code =>
+                $"Model servisi istegi basarisiz oldu ({(int)code}). Detaylar loglara yazildi.",
+            null =>
+                "Model servisi istegi basarisiz oldu. Detaylar loglara yazildi."
+        };
+    }
+
+    private static async Task<string> InvokePromptStreamingAsync(
+        Kernel kernel,
+        string prompt,
+        OpenAIPromptExecutionSettings settings,
+        Func<string, Task> onTextDelta,
+        CancellationToken cancellationToken)
+    {
+        var output = new StringBuilder();
+        await foreach (var chunk in kernel.InvokePromptStreamingAsync(
+            prompt,
+            new KernelArguments(settings),
+            cancellationToken: cancellationToken))
+        {
+            var text = chunk.ToString();
+            if (string.IsNullOrEmpty(text))
+            {
+                continue;
+            }
+
+            output.Append(text);
+            await onTextDelta(text);
+        }
+
+        return output.ToString();
+    }
+
+    private async Task<string> BuildMemoryContextAsync(AgentRequest request, string userText)
+    {
+        var memories = new List<string>();
+
+        foreach (var memory in request.Subs.Where(sub => sub.PortType == Domain.Nodes.NodePortType.AiMemory))
+        {
+            var startedAt = DateTimeOffset.UtcNow;
+            var item = NodeItem.From(new JsonObject
+            {
+                ["input"] = userText,
+                ["text"] = userText
+            });
+            var parameters = NormalizeMemoryParameters(memory.Parameters, userText);
+            var context = request.ContextFactory(memory.Type, memory.Name, parameters, [item]);
+            var memoryType = registry.Find(memory.Type);
+
+            if (memoryType is null)
+            {
+                await NotifySubNodeAsync(request, memory, NodeRunStatus.Skipped, new JsonObject(), "Memory node tipi bulunamadi.", startedAt, 0);
+                continue;
+            }
+
+            NodeExecutionResult result;
+            try
+            {
+                result = await memoryType.ExecuteAsync(context);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                logger.LogWarning(exception, "AI Agent '{Name}' memory node '{Memory}' calistirilamadi.", request.AgentName, memory.Name);
+                await NotifySubNodeAsync(request, memory, NodeRunStatus.Failed, new JsonObject(), "Memory sorgusu calistirilamadi. Detaylar loglara yazildi.", startedAt, 0);
+                continue;
+            }
+
+            if (!result.Succeeded)
+            {
+                await NotifySubNodeAsync(request, memory, NodeRunStatus.Failed, new JsonObject(), result.Error, startedAt, 0);
+                continue;
+            }
+
+            var output = new JsonArray();
+            foreach (var match in result.PrimaryItems)
+            {
+                output.Add(match.Json.DeepClone());
+                var text = match.Json["text"]?.ToString();
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    memories.Add($"- {text}");
+                }
+            }
+
+            await NotifySubNodeAsync(request, memory, NodeRunStatus.Succeeded, output, null, startedAt, result.PrimaryItems.Count);
+        }
+
+        return string.Join('\n', memories);
+    }
+
+    private async Task SaveConversationMemoryAsync(
+        AgentRequest request,
+        string userText,
+        string assistantText,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(userText) || string.IsNullOrWhiteSpace(assistantText))
+        {
+            return;
+        }
+
+        foreach (var memory in request.Subs.Where(sub => sub.PortType == Domain.Nodes.NodePortType.AiMemory))
+        {
+            var item = NodeItem.From(new JsonObject
+            {
+                ["input"] = userText,
+                ["text"] = userText
+            });
+            var parameters = NormalizeMemoryParameters(memory.Parameters, userText);
+            var context = request.ContextFactory(memory.Type, memory.Name, parameters, [item]);
+
+            try
+            {
+                var embedder = context.Services.GetRequiredService<IEmbeddingGenerator>();
+                var store = context.Services.GetRequiredService<IVectorStore>();
+                var scope = context.WorkflowId?.ToString("N") ?? "global";
+                var collection = context.GetString("collection") ?? "default";
+                var text = $"Kullanici: {userText}\nAsistan: {assistantText}";
+                var vector = (await embedder.EmbedAsync([text], cancellationToken))[0];
+                var metadata = new JsonObject
+                {
+                    ["type"] = "chat",
+                    ["user"] = userText,
+                    ["assistant"] = assistantText,
+                    ["createdAt"] = DateTimeOffset.UtcNow.ToString("O")
+                }.ToJsonString();
+
+                await store.UpsertAsync(scope, collection,
+                    [new VectorRecord($"chat-{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}-{Guid.NewGuid():N}", text, vector, metadata)],
+                    cancellationToken);
+
+                await NotifySubNodeAsync(request, memory, NodeRunStatus.Succeeded, new JsonObject
+                {
+                    ["collection"] = collection,
+                    ["inserted"] = 1
+                }, null, DateTimeOffset.UtcNow, 1);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                logger.LogWarning(exception, "AI Agent '{Name}' konusma hafizasi kaydedilemedi.", request.AgentName);
+                await NotifySubNodeAsync(request, memory, NodeRunStatus.Failed, new JsonObject(), "Konusma hafizasi kaydedilemedi. Detaylar loglara yazildi.", DateTimeOffset.UtcNow, 0);
+            }
+        }
+    }
+
+    private static JsonObject NormalizeMemoryParameters(JsonObject parameters, string userText)
+    {
+        var normalized = parameters.DeepClone().AsObject();
+        var query = normalized.TryGetPropertyValue("query", out var value) ? value?.ToString() : null;
+        if (string.IsNullOrWhiteSpace(query) ||
+            query.Equals("{{$json.input}}", StringComparison.OrdinalIgnoreCase) ||
+            query.Equals("{{$json.text}}", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized["query"] = userText;
+        }
+
+        return normalized;
+    }
+
+    private static string ResolveAgentUserText(string? configuredText, IReadOnlyList<NodeItem> input)
+    {
+        if (!string.IsNullOrWhiteSpace(configuredText))
+        {
+            return configuredText;
+        }
+
+        var json = input.FirstOrDefault()?.Json;
+        if (json is null)
+        {
+            return string.Empty;
+        }
+
+        foreach (var key in new[] { "text", "chatInput", "input", "message", "value" })
+        {
+            if (json.TryGetPropertyValue(key, out var value) && value is not null)
+            {
+                var text = value.ToString();
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    return text;
+                }
+            }
+        }
+
+        return json.ToJsonString();
+    }
+
+    private async Task<string> InvokeToolAsync(AgentRequest request, AgentSubNode tool, string query, AgentContextFactory contextFactory)
+    {
+        var startedAt = DateTimeOffset.UtcNow;
         var toolType = registry.Find(tool.Type);
         if (toolType is null)
         {
+            await NotifySubNodeAsync(request, tool, NodeRunStatus.Skipped, new JsonObject(), "Arac bulunamadi.", startedAt, 0);
             return "Arac bulunamadi.";
         }
 
         var item = NodeItem.From(new JsonObject { ["input"] = query });
         var context = contextFactory(tool.Type, tool.Name, tool.Parameters, [item]);
         var result = await toolType.ExecuteAsync(context);
-        return result.PrimaryItems.FirstOrDefault()?.Json.ToJsonString() ?? "";
+        var primary = result.PrimaryItems.FirstOrDefault();
+        await NotifySubNodeAsync(request, tool, result.Succeeded ? NodeRunStatus.Succeeded : NodeRunStatus.Failed,
+            primary?.Json.DeepClone() ?? new JsonObject(), result.Error, startedAt, result.PrimaryItems.Count);
+        return primary?.Json.ToJsonString() ?? "";
+    }
+
+    private static async Task NotifySubNodeAsync(
+        AgentRequest? request,
+        AgentSubNode subNode,
+        NodeRunStatus status,
+        JsonNode output,
+        string? error,
+        DateTimeOffset startedAt,
+        int itemCount)
+    {
+        if (request?.OnSubNodeCompleted is null)
+        {
+            return;
+        }
+
+        await request.OnSubNodeCompleted(new NodeRunData(
+            subNode.Id,
+            subNode.Name,
+            subNode.Type,
+            status,
+            output,
+            error,
+            startedAt,
+            DateTimeOffset.UtcNow,
+            itemCount));
     }
 
     private static (string Provider, string CredentialType, string DefaultModel) GetProviderDetails(string modelType) =>

--- a/src/FlowSharp.Nodes/Ai/Rag/RagQueryNode.cs
+++ b/src/FlowSharp.Nodes/Ai/Rag/RagQueryNode.cs
@@ -59,3 +59,60 @@ public sealed class RagQueryNode : NodeType
         return NodeExecutionResult.Single(items);
     }
 }
+
+/// <summary>
+/// AI Agent'in Memory portuna baglanan RAG hafizasi. Agent calisirken kullanici girdisini
+/// vektor deposunda arar ve bulunan metinleri model prompt'una baglam olarak ekler.
+/// </summary>
+public sealed class RagMemoryNode : NodeType
+{
+    public override NodeDefinition Definition { get; } = new(
+        Key: "rag.memory",
+        DisplayName: "Vector Store: Memory",
+        Category: NodeCategory.Ai,
+        Kind: NodeKind.Ai,
+        Description: "AI Agent icin vektor deposundan ilgili baglam getirir.",
+        Parameters:
+        [
+            new NodeParameterDefinition("collection", "Koleksiyon", NodeParameterType.String, IsRequired: true,
+                DefaultValue: "default"),
+            new NodeParameterDefinition("query", "Sorgu", NodeParameterType.String, IsRequired: true,
+                DefaultValue: "{{$json.input}}",
+                HelpText: "Aranacak metin. Agent girdisi icin varsayilan: {{$json.input}}"),
+            new NodeParameterDefinition("topK", "Sonuc sayisi", NodeParameterType.Number, DefaultValue: "4")
+        ],
+        Tags: ["ai", "rag", "memory", "vector"],
+        Icon: "database",
+        Color: "#10a37f",
+        Inputs: [],
+        Outputs: [new NodePort("memory", "Memory", NodePortType.AiMemory)]);
+
+    public override async Task<NodeExecutionResult> ExecuteAsync(INodeExecutionContext context)
+    {
+        var embedder = context.Services.GetRequiredService<IEmbeddingGenerator>();
+        var store = context.Services.GetRequiredService<IVectorStore>();
+
+        var scope = context.WorkflowId?.ToString("N") ?? "global";
+        var collection = context.GetString("collection") ?? "default";
+        var query = context.GetString("query") ?? "";
+        var topK = Math.Max(1, context.GetInt("topK", defaultValue: 4));
+
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return NodeExecutionResult.Single([]);
+        }
+
+        var vectors = await embedder.EmbedAsync([query], context.CancellationToken);
+        var matches = await store.SearchAsync(scope, collection, vectors[0], topK, context.CancellationToken);
+
+        var items = matches.Select(match => NodeItem.From(new JsonObject
+        {
+            ["id"] = match.Id,
+            ["text"] = match.Text,
+            ["score"] = match.Score,
+            ["metadata"] = match.Metadata
+        })).ToList();
+
+        return NodeExecutionResult.Single(items);
+    }
+}

--- a/src/FlowSharp.Nodes/Triggers/ChatTriggerNode.cs
+++ b/src/FlowSharp.Nodes/Triggers/ChatTriggerNode.cs
@@ -17,7 +17,15 @@ namespace FlowSharp.Nodes.Triggers
             Category: NodeCategory.Trigger,
             Kind: NodeKind.Trigger,
             Description: "Sohbet penceresinden mesaj geldiginde workflow'u baslatir.",
-            Parameters: [],
+            Parameters:
+            [
+                new NodeParameterDefinition(
+                    "chatStream",
+                    "ChatStream",
+                    NodeParameterType.Boolean,
+                    DefaultValue: "true",
+                    HelpText: "AI cevabini destekleyen modellerde parca parca sohbet penceresine aktarir.")
+            ],
             Tags: ["trigger", "ai"],
             Icon: "message-circle",
             Color: "#10a37f",

--- a/src/FlowSharp.Web/Components/Pages/WorkflowDesigner.razor
+++ b/src/FlowSharp.Web/Components/Pages/WorkflowDesigner.razor
@@ -514,7 +514,7 @@
             {
                 <div class="nwf-chat-msg @(msg.IsUser ? "user" : "bot")">@msg.Text</div>
             }
-            @if (chatBusy)
+            @if (ShowTyping)
             {
                 <div class="nwf-chat-msg bot typing">
                     <span class="dot"></span>

--- a/src/FlowSharp.Web/Components/Pages/WorkflowDesigner.razor.cs
+++ b/src/FlowSharp.Web/Components/Pages/WorkflowDesigner.razor.cs
@@ -75,6 +75,7 @@ public partial class WorkflowDesigner : IAsyncDisposable
         }
 
         if (def.Key == "ai.agent") return "AI Agents";
+        if (def.Key.StartsWith("rag.", StringComparison.OrdinalIgnoreCase)) return "AI Memory";
         return "AI Chat Nodes (Main Akış)";
     }
 
@@ -101,6 +102,8 @@ public partial class WorkflowDesigner : IAsyncDisposable
     private readonly List<ChatMessage> chatMessages = [];
     private string? chatInput;
     private bool chatBusy;
+    private bool ShowTyping => chatBusy &&
+        (chatMessages.LastOrDefault() is not { IsUser: false } lastBot || string.IsNullOrWhiteSpace(lastBot.Text));
     private bool credAddOpen;
     private string? credAddParamKey;
     private string credAddName = "";
@@ -371,10 +374,7 @@ public partial class WorkflowDesigner : IAsyncDisposable
             X = 160 + nodes.Count % 4 * 60,
             Y = 120 + nodes.Count % 5 * 40
         };
-        foreach (var p in def.Parameters.Where(p => p.DefaultValue is not null))
-        {
-            node.Parameters[p.Key] = p.DefaultValue!;
-        }
+        ApplyDefaultParameters(node);
         nodes.Add(node);
         selectedId = node.InstanceId;
         needsSync = true;
@@ -605,6 +605,7 @@ public partial class WorkflowDesigner : IAsyncDisposable
                 var y = item.TryGetProperty("position", out pos) && pos.TryGetProperty("y", out var yv) ? yv.GetInt32() : 120;
 
                 var node = new DesignerNode { InstanceId = id, NodeKey = type, Name = name, Category = category, X = x, Y = y };
+                ApplyDefaultParameters(node);
                 if (item.TryGetProperty("parameters", out var prms) && prms.ValueKind == JsonValueKind.Object)
                 {
                     foreach (var prop in prms.EnumerateObject())
@@ -630,6 +631,20 @@ public partial class WorkflowDesigner : IAsyncDisposable
                     connections.Add(new DesignerConnection(from, fromPort, to, toPort));
                 }
             }
+        }
+    }
+
+    private void ApplyDefaultParameters(DesignerNode node)
+    {
+        var def = Definition(node.NodeKey);
+        if (def is null)
+        {
+            return;
+        }
+
+        foreach (var parameter in def.Parameters.Where(parameter => parameter.DefaultValue is not null))
+        {
+            node.Parameters.TryAdd(parameter.Key, parameter.DefaultValue!);
         }
     }
 
@@ -717,6 +732,14 @@ public partial class WorkflowDesigner : IAsyncDisposable
         {
             current = upItems[0];
         }
+        else if (IsAgentMemoryNode(node))
+        {
+            current = NodeItem.From(new JsonObject
+            {
+                ["input"] = "Agent input",
+                ["text"] = "Agent input"
+            });
+        }
 
         return new FlowSharp.Application.Nodes.Expressions.ExpressionContext
         {
@@ -724,6 +747,13 @@ public partial class WorkflowDesigner : IAsyncDisposable
             ItemIndex = 0,
             NodeOutputs = outputs
         };
+    }
+
+    private bool IsAgentMemoryNode(DesignerNode node)
+    {
+        var def = Definition(node.NodeKey);
+        return def is { IsSubNode: true } &&
+            def.SubOutputPorts.Any(port => port.Type == NodePortType.AiMemory);
     }
 
     private static IReadOnlyList<NodeItem> ParseItems(string? json)
@@ -807,26 +837,76 @@ public partial class WorkflowDesigner : IAsyncDisposable
         if (string.IsNullOrEmpty(message) || chatBusy) return;
 
         chatMessages.Add(new ChatMessage(true, message));
+        var botMessage = new ChatMessage(false, "");
+        chatMessages.Add(botMessage);
         chatInput = "";
         chatBusy = true;
+        foreach (var n in nodes) n.Status = "";
+        runOutputs.Clear();
         StateHasChanged();
 
         try
         {
             var payload = JsonDocument.Parse(JsonSerializer.Serialize(new { source = "chat", chatInput = message, text = message }));
+            var chatStreamEnabled = IsChatStreamEnabled();
+            var options = new WorkflowExecutionOptions
+            {
+                WorkflowId = WorkflowId,
+                OnTextDelta = chatStreamEnabled
+                    ? async delta =>
+                    {
+                        await InvokeAsync(() =>
+                        {
+                            botMessage.Text += delta;
+                            StateHasChanged();
+                        });
+                    }
+                    : null,
+                OnNodeCompleted = async data =>
+                {
+                    var node = nodes.FirstOrDefault(n => n.InstanceId == data.NodeId);
+                    if (node is not null) node.Status = data.Status.ToString();
+                    runOutputs[data.NodeId] = new RunOutput(data.ItemCount,
+                        data.Output.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+                    await InvokeAsync(StateHasChanged);
+                    await SyncGraphAsync();
+
+                    if (WorkflowId.HasValue)
+                    {
+                        await EventPublisher.PublishNodeCompletedAsync(WorkflowId.Value, Guid.Empty, data);
+                    }
+                }
+            };
+
             var result = await Engine.ExecuteAsync(BuildDefinition().RootElement, payload.RootElement,
-                new WorkflowExecutionOptions { WorkflowId = WorkflowId });
-            chatMessages.Add(new ChatMessage(false, ExtractReply(result)));
+                options);
+            if (!result.Succeeded || string.IsNullOrWhiteSpace(botMessage.Text))
+            {
+                botMessage.Text = ExtractReply(result);
+            }
         }
         catch (Exception ex)
         {
-            chatMessages.Add(new ChatMessage(false, $"Hata: {ex.Message}"));
+            botMessage.Text = $"Hata: {ex.Message}";
         }
         finally
         {
             chatBusy = false;
             StateHasChanged();
         }
+    }
+
+    private bool IsChatStreamEnabled()
+    {
+        var trigger = nodes.FirstOrDefault(n => n.NodeKey == "chat.trigger");
+        if (trigger is null)
+        {
+            return true;
+        }
+
+        return !trigger.Parameters.TryGetValue("chatStream", out var value) ||
+            !bool.TryParse(value, out var enabled) ||
+            enabled;
     }
 
     private static string ExtractReply(WorkflowRunResult result)
@@ -881,7 +961,11 @@ public partial class WorkflowDesigner : IAsyncDisposable
 
     private sealed record RunOutput(int ItemCount, string Json);
 
-    private sealed record ChatMessage(bool IsUser, string Text);
+    private sealed class ChatMessage(bool isUser, string text)
+    {
+        public bool IsUser { get; } = isUser;
+        public string Text { get; set; } = text;
+    }
 
     private sealed class CredField
     {

--- a/src/FlowSharp.Web/Components/Pages/Workflows.razor
+++ b/src/FlowSharp.Web/Components/Pages/Workflows.razor
@@ -18,9 +18,12 @@
                 <MudText Typo="Typo.h4" Class="Fsharp-title">@L["nav.workflows"]</MudText>
                 <MudText Typo="Typo.body1" Color="Color.Secondary">@L["workflows.summary"]</MudText>
             </div>
-            <MudButton Href="workflows/designer" Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add">
-                @L["home.new_workflow"]
-            </MudButton>
+            @if (canWrite)
+            {
+                <MudButton Href="workflows/designer" Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add">
+                    @L["home.new_workflow"]
+                </MudButton>
+            }
         </MudStack>
 
         @if (workflows is null)
@@ -33,9 +36,12 @@
                 <MudIcon Icon="@Icons.Material.Filled.AccountTree" Size="Size.Large" Color="Color.Secondary" />
                 <MudText Typo="Typo.h6">@L["workflows.empty.title"]</MudText>
                 <MudText Color="Color.Secondary">@L["workflows.empty.summary"]</MudText>
-                <MudButton Href="workflows/designer" Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add">
-                    @L["workflows.empty.open_designer"]
-                </MudButton>
+                @if (canWrite)
+                {
+                    <MudButton Href="workflows/designer" Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add">
+                        @L["workflows.empty.open_designer"]
+                    </MudButton>
+                }
             </MudPaper>
         }
         else
@@ -58,10 +64,19 @@
                                 </MudStack>
                             </MudCardContent>
                             <MudCardActions>
-                                <MudButton Href="@($"workflows/designer/{wf.Id}")" Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Edit">@L["common.edit"]</MudButton>
-                                <MudButton Variant="Variant.Text" Color="Color.Success" StartIcon="@Icons.Material.Filled.PlayArrow" OnClick="() => RunAsync(wf.Id)">@L["common.run"]</MudButton>
+                                @if (canWrite)
+                                {
+                                    <MudButton Href="@($"workflows/designer/{wf.Id}")" Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Edit">@L["common.edit"]</MudButton>
+                                }
+                                @if (canExecute)
+                                {
+                                    <MudButton Variant="Variant.Text" Color="Color.Success" StartIcon="@Icons.Material.Filled.PlayArrow" OnClick="() => RunAsync(wf.Id)">@L["common.run"]</MudButton>
+                                }
                                 <MudSpacer />
-                                <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="() => DeleteAsync(wf.Id)" />
+                                @if (canWrite)
+                                {
+                                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="() => DeleteAsync(wf.Id)" />
+                                }
                             </MudCardActions>
                         </MudCard>
                     </MudItem>

--- a/src/FlowSharp.Web/Components/Pages/Workflows.razor.cs
+++ b/src/FlowSharp.Web/Components/Pages/Workflows.razor.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
@@ -6,6 +8,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using FlowSharp.Application.Abstractions;
+using FlowSharp.Domain.Security;
 using FlowSharp.Domain.Workflows;
 using FlowSharp.Infrastructure.Data;
 
@@ -17,11 +20,19 @@ public partial class Workflows
     [Inject] public IWorkflowQueue Queue { get; set; } = default!;
     [Inject] public IWebhookRegistrar WebhookRegistrar { get; set; } = default!;
     [Inject] public NavigationManager Navigation { get; set; } = default!;
+    [Inject] public IAuthorizationService AuthorizationService { get; set; } = default!;
+    [Inject] public AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
 
     private List<Workflow>? workflows;
     private string? message;
+    private bool canWrite;
+    private bool canExecute;
 
-    protected override async Task OnInitializedAsync() => await ReloadAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadPermissionsAsync();
+        await ReloadAsync();
+    }
 
     private async Task ReloadAsync()
     {
@@ -33,16 +44,35 @@ public partial class Workflows
 
     private async Task RunAsync(Guid id)
     {
+        if (!canExecute)
+        {
+            await Flash("Workflow calistirma yetkiniz yok.");
+            return;
+        }
+
         await Queue.EnqueueAsync(id, JsonDocument.Parse("""{"source":"manual"}"""));
         await Flash("Workflow kuyruga alindi.");
     }
 
     private async Task DeleteAsync(Guid id)
     {
+        if (!canWrite)
+        {
+            await Flash("Workflow silme yetkiniz yok.");
+            return;
+        }
+
         await WebhookRegistrar.SyncAsync(id, JsonDocument.Parse("""{"nodes":[]}""").RootElement, false);
         await DbContext.Workflows.Where(w => w.Id == id).ExecuteDeleteAsync();
         await ReloadAsync();
         await Flash("Workflow silindi.");
+    }
+
+    private async Task LoadPermissionsAsync()
+    {
+        var user = (await AuthenticationStateProvider.GetAuthenticationStateAsync()).User;
+        canWrite = (await AuthorizationService.AuthorizeAsync(user, AppPermissions.WorkflowsWrite)).Succeeded;
+        canExecute = (await AuthorizationService.AuthorizeAsync(user, AppPermissions.WorkflowsExecute)).Succeeded;
     }
 
     private async Task Flash(string text)

--- a/src/FlowSharp.Web/Endpoints/WebhookEndpoints.cs
+++ b/src/FlowSharp.Web/Endpoints/WebhookEndpoints.cs
@@ -20,10 +20,12 @@ public static class WebhookEndpoints
         HttpContext httpContext,
         IWebhookRegistrar registrar,
         IWorkflowRunner runner,
+        ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
         var request = httpContext.Request;
         var response = httpContext.Response;
+        var logger = loggerFactory.CreateLogger("WebhookEndpoints");
 
         var match = await registrar.ResolveAsync(request.Method, path, cancellationToken);
         if (match is null)
@@ -43,8 +45,10 @@ public static class WebhookEndpoints
         }
         catch (Exception exception)
         {
+            logger.LogError(exception, "Webhook calismasi sirasinda hata olustu. Method: {Method}, Path: {Path}, WorkflowId: {WorkflowId}",
+                request.Method, path, match.WorkflowId);
             await WriteJsonAsync(response, StatusCodes.Status500InternalServerError,
-                new JsonObject { ["error"] = exception.Message }, cancellationToken);
+                new JsonObject { ["error"] = "Webhook calismasi basarisiz." }, cancellationToken);
             return;
         }
 
@@ -69,8 +73,10 @@ public static class WebhookEndpoints
         }
         else
         {
+            logger.LogWarning("Webhook calismasi basarisiz. Method: {Method}, Path: {Path}, WorkflowId: {WorkflowId}, Error: {Error}",
+                request.Method, path, match.WorkflowId, result.Error);
             await WriteJsonAsync(response, StatusCodes.Status500InternalServerError,
-                new JsonObject { ["error"] = result.Error ?? "Workflow calismasi basarisiz." }, cancellationToken);
+                new JsonObject { ["error"] = "Webhook calismasi basarisiz." }, cancellationToken);
         }
     }
 

--- a/src/FlowSharp.Web/appsettings.json
+++ b/src/FlowSharp.Web/appsettings.json
@@ -11,6 +11,13 @@
   "Worker": {
     "RunInWebProcess": false
   },
+  "Security": {
+    "CredentialEncryptionKey": "sU7uc/MSLu+Aib+HM5nrQXwPifVu+UYwbmu6rfwtYBU="
+  },
+  "HttpNodes": {
+    "Exposure": "Local",
+    "BlockPrivateNetworks": false
+  },
   "Executions": {
     "SaveData": "All",
     "MaxCount": 1000,

--- a/src/FlowSharp.Worker/appsettings.json
+++ b/src/FlowSharp.Worker/appsettings.json
@@ -8,6 +8,13 @@
   "Redis": {
     "ConnectionString": "localhost:6379"
   },
+  "Security": {
+    "CredentialEncryptionKey": "sU7uc/MSLu+Aib+HM5nrQXwPifVu+UYwbmu6rfwtYBU="
+  },
+  "HttpNodes": {
+    "Exposure": "Local",
+    "BlockPrivateNetworks": false
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",


### PR DESCRIPTION
Introduce security guidance and runtime/config improvements; add network-level protections and AI streaming support.

- Add SECURITY.md with deployment and ops guidance.
- Add Directory.Build.props and Dockerfile ARGs to control RuntimeIdentifier for Web/Worker builds and avoid shipping unnecessary native assets.
- Register HttpNodeNetworkOptions and PrivateNetworkBlockingHandler in DI and add a DelegatingHandler that blocks private/localhost targets when configured (HttpNodes settings).
- Tighten CredentialProtector: require a base64 32-byte Security:CredentialEncryptionKey and fail startup if missing or invalid.
- Extend workflow/agent APIs: add OnTextDelta streaming callback and OnSubNodeCompleted propagation; include sub-node Id in AgentSubNode.
- Enhance SemanticKernelAgentExecutor: support streaming responses to UI, memory nodes (RAG) integration, per-subnode notifications, better error handling, and saving conversation memory to vector store.
- Add RagMemoryNode as a Memory-type node for vector lookups.
- Update WorkflowDesigner and Workflows UI: enable chat streaming/typing indicator, apply default node parameters when creating/loading nodes, handle streaming updates in the chat UI, and hide designer buttons when user lacks write permission.

These changes improve security posture, prevent unintended internal network access from HTTP nodes, and add live streaming/memory features for AI agents with corresponding UI support.