### PR TITLE
Add SQLite support and docs overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,369 +2,153 @@
 
 ![FlowSharp workflow automation hero](docs/assets/flowsharp-hero.png)
 
-> 🌐 **Languages:** [English](README.md) · [Türkçe](README.tr.md)
+FlowSharp is a node-based workflow automation platform built with **C#**, **.NET 10**, and **Blazor**. It includes a visual workflow designer, executable automation nodes, AI agent support, webhook and schedule triggers, background workers, and runtime-loadable C# plugins.
 
-An enterprise-grade **workflow automation** platform built with **C# / .NET 10 and Blazor**. It ships with a node-based visual flow designer, real executable nodes, AI agent support, scheduled/webhook triggers, and a **hot-loadable community plugin system**.
+![FlowSharp workflow designer](docs/assets/flowsharp-designer-mockup.png)
 
-![FlowSharp Workflow Designer dark and light UI mockup](docs/assets/flowsharp-designer-mockup.png)
+## Highlights
 
----
-
-## Table of Contents
-
-- [Features](#features)
-- [Architecture](#architecture)
-- [Libraries Used](#libraries-used)
-- [Built-in Nodes](#built-in-nodes)
-- [Prerequisites](#prerequisites)
-- [How to Install](#how-to-install)
-- [Configuration (appsettings.json)](#configuration-appsettingsjson)
-- [Roles and Permissions](#roles-and-permissions)
-- [Plugin System (Community Nodes)](#plugin-system-community-nodes)
-- [Writing a New Node](#writing-a-new-node)
-- [Webhook and Response (Respond to Webhook)](#webhook-and-response-respond-to-webhook)
-- [Project Structure](#project-structure)
-- [Sponsorship & Support](#sponsorship--support)
-- [License](#license)
-- [Troubleshooting](#troubleshooting)
-- [Contributing](#contributing)
-
----
-
-## Features
-
-- 🎨 **Visual Workflow Designer** — add/connect nodes, category & search filters, parameter editing.
-- ⚡ **Real Executable Nodes** — HTTP, email (SMTP/IMAP), PostgreSQL, Slack/Telegram/Discord, logic (IF/Switch/Filter/Merge), data transforms, and JavaScript (Jint).
-- 🤖 **AI Agent** — via Semantic Kernel: OpenAI, Azure OpenAI, Anthropic, Gemini, Groq, Mistral, Cohere, HuggingFace, OpenRouter, and Ollama; supports attaching tools.
-- ⏰ **Triggers** — Manual, Cron schedule, Webhook (can return a synchronous response), IMAP email, and Chat.
-- 🔌 **Hot Plugin System** — raw `.cs` files dropped into `plugins/` are compiled at runtime with **Roslyn**; nodes are added **without rebuilding** the main app.
-- 🛒 **Admin Marketplace** — download, install, reload, and remove plugins from a GitHub repository.
-- 🔐 **Identity & Authorization** — ASP.NET Core Identity + role/permission policy infrastructure.
-- 📡 **Real Time** — live node execution status via SignalR (Redis or in-memory fallback).
-- 🧮 **Expression Engine** — `{{ $json.field }}`, `{{ $node["Name"].json }}`, `{{ $now }}`, etc., with **live validation** (green/red) in the designer.
-- 📝 **Logging** — Serilog console and rolling file sinks.
-
----
-
-## Architecture
-
-| Layer | Technology |
-|---|---|
-| UI | Blazor Web App (interactive server render) |
-| Backend | ASP.NET Core (.NET 10) |
-| Real time | SignalR + Redis (or in-memory) |
-| Database | PostgreSQL |
-| ORM | EF Core + JSONB workflow definition |
-| Identity | ASP.NET Core Identity |
-| Authorization | role/permission policies (`AppPermissions`) |
-| Queue | PostgreSQL-backed `workflow_jobs` table |
-| Worker | separate `BackgroundService` project |
-| Plugins | Roslyn runtime compilation + `AssemblyLoadContext` |
-| AI | Microsoft Semantic Kernel |
-| Logging | Serilog (console + file) |
-
----
+- Visual workflow designer with node palette, connections, parameters, and run status.
+- Executable nodes for HTTP, email, PostgreSQL, logic, data transforms, JavaScript, communication services, and AI.
+- AI agents powered by Semantic Kernel with model and tool sub-nodes.
+- Webhook, manual, schedule, chat, IMAP, workflow, and error triggers.
+- Runtime plugin system: drop C# source files into `plugins/` and load new nodes without rebuilding the app.
+- ASP.NET Core Identity, role/permission policies, encrypted credentials, SignalR live events, and Serilog logs.
 
 ## Libraries Used
 
 | Package | Version | Purpose |
 |---|---|---|
 | `Microsoft.SemanticKernel` | 1.77.0 | AI Agent and chat models |
+| `MudBlazor` | 9.5.0 | UI components |
 | `MailKit` | 4.17.0 | SMTP sending and IMAP reading |
-| `Jint` | 4.9.2 | Code node — sandboxed JavaScript |
-| `CsvHelper` | 33.0.1 | CSV node — read/write CSV |
-| `AngleSharp` | 1.1.2 | HTML Extract node — CSS selector parsing |
-| `ClosedXML` | 0.104.2 | Spreadsheet node — Excel (.xlsx) reading |
-| `Microsoft.Data.Sqlite` | 10.0.0 | RAG — SQLite vector store (per workspace) |
-| `SmartComponents.LocalEmbeddings` | 0.1.0-preview10148 | RAG — local/in-process embeddings (bundled ONNX) |
+| `Jint` | 4.9.2 | Code node - sandboxed JavaScript |
+| `CsvHelper` | 33.0.1 | CSV node - read/write CSV |
+| `AngleSharp` | 1.1.2 | HTML Extract node - CSS selector parsing |
+| `ClosedXML` | 0.104.2 | Spreadsheet node - Excel (.xlsx) reading |
+| `Microsoft.Data.Sqlite` | 10.0.0 | RAG - SQLite vector store |
+| `SmartComponents.LocalEmbeddings` | 0.1.0-preview10148 | RAG - local/in-process embeddings |
 | `Npgsql.EntityFrameworkCore.PostgreSQL` | 10.0.2 | PostgreSQL + EF Core |
+| `Microsoft.EntityFrameworkCore.SqlServer` | 10.0.8 | SQL Server + EF Core |
+| `Microsoft.EntityFrameworkCore.Sqlite` | 10.0.8 | SQLite + EF Core |
 | `Microsoft.EntityFrameworkCore.Design` / `.Tools` | 10.0.8 | Migration tooling |
 | `Microsoft.AspNetCore.Identity.EntityFrameworkCore` | 10.0.8 | Identity storage |
-| `Microsoft.CodeAnalysis.CSharp` (+ Workspaces) | 5.3.0 | **Roslyn** — runtime plugin compilation |
-| `StackExchange.Redis` | 2.13.17 | SignalR event backplane (multi-process) |
-| `Cronos` | 0.13.0 | Cron expression parsing (scheduler) |
-| `Serilog.AspNetCore` / `Sinks.Console` / `Sinks.File` | 10.0.0 / 6.1.1 / 7.0.0 | Logging |
-| `Microsoft.Extensions.Hosting` | 10.0.8 | Worker host infrastructure |
+| `Microsoft.CodeAnalysis.CSharp` / Workspaces | 5.3.0 | Roslyn runtime plugin compilation |
+| `StackExchange.Redis` | 2.13.17 | Workflow event backplane |
+| `Cronos` | 0.13.0 | Cron expression parsing |
+| `Serilog.AspNetCore` / Sinks | 10.0.0 / 6.1.1 / 7.0.0 | Logging |
 
----
+## Quick Start
 
-## Built-in Nodes
-
-All nodes are **auto-discovered** as `INodeType` implementations and appear in the palette under their category.
-
-### Triggers
-| Key | Name | Description |
-|---|---|---|
-| `manual.trigger` | Manual Trigger | Starts the flow manually |
-| `schedule.trigger` | Schedule Trigger | Runs periodically via a cron expression |
-| `webhook.trigger` | Webhook | Starts on an incoming HTTP request (can respond synchronously) |
-| `email.imap.trigger` | Email Trigger (IMAP) | Triggers when new mail arrives in the inbox |
-| `chat.trigger` | AI Chat UI | Triggers from the chat interface |
-| `flow.executeWorkflowTrigger` | Execute Workflow Trigger | Starts when called by another workflow |
-| `error.trigger` | Error Trigger | Runs when a workflow fails |
-
-### Core / Logic
-| Key | Name | Description |
-|---|---|---|
-| `if.condition` | IF | Branches true/false on a condition |
-| `switch.condition` | Switch | Branches to multiple outputs |
-| `filter.items` | Filter | Passes items matching a condition |
-| `merge.items` | Merge | Combines multiple inputs |
-| `set.fields` | Set | Adds/edits fields |
-| `no.op` | No Operation | Passes data through unchanged |
-| `code.javascript` | Code | Runs sandboxed JavaScript (Jint) |
-| `flow.wait` | Wait | Pauses the flow for a given duration |
-| `flow.stopAndError` | Stop And Error | Stops the flow with a custom error message |
-| `flow.executeWorkflow` | Execute Workflow | Runs a sub-workflow and returns its output |
-| `flow.loopOverItems` | Loop Over Items | Processes items in batches; `loop`/`done` outputs |
-
-### Data / Transform
-| Key | Name | Description |
-|---|---|---|
-| `sort.items` | Sort | Sorts items by a field |
-| `limit.items` | Limit | Caps the number of items |
-| `aggregate.items` | Aggregate | Collapses all items into one |
-| `split.out` | Split Out | Splits an array field into separate items |
-| `datetime.action` | Date & Time | Produces or formats date/time |
-| `transform.crypto` | Crypto | Hash / HMAC / Base64 operations |
-| `transform.csv` | CSV | Converts items to CSV or parses CSV into items |
-| `transform.htmlExtract` | HTML Extract | Extracts data from HTML via CSS selectors |
-| `transform.spreadsheet` | Spreadsheet | Reads an uploaded Excel/CSV file; each row becomes an item |
-
-### HTTP
-| Key | Name | Description |
-|---|---|---|
-| `http.request` | HTTP Request | Full REST request with selectable method |
-| `http.get` / `http.post` / `http.put` / `http.patch` / `http.delete` | HTTP GET/POST/... | Fixed-method requests |
-| `webhook.response` | Respond to Webhook | Returns a custom response to the webhook caller |
-
-### Database
-| Key | Name | Description |
-|---|---|---|
-| `postgres.query` | Postgres | Runs a SQL query (select/execute) |
-
-### Communication
-| Key | Name | Description |
-|---|---|---|
-| `email.send` | Send Email | Sends email over SMTP (MailKit) |
-| `telegram.message` | Telegram | Sends a Telegram message |
-| `slack.message` | Slack | Sends a Slack channel message |
-| `discord.message` | Discord | Sends to a Discord webhook |
-
-### AI
-| Key | Name | Description |
-|---|---|---|
-| `ai.agent` | AI Agent | Tool-calling AI agent |
-| `openai.chat` / `azureopenai.chat` / `anthropic.chat` / `gemini.chat` / `groq.chat` / `mistral.chat` / `cohere.chat` / `huggingface.chat` / `openrouter.chat` / `ollama.chat` | *Provider* Chat | Direct chat completion |
-| `*.chatmodel` | *Provider* Chat Model | Model sub-node attached to AI Agent |
-| `tool.httpRequest` | HTTP Request Tool | HTTP tool for the agent |
-| `tool.calculator` | Calculator | Calculator tool for the agent |
-| `rag.insert` | Vector Store: Insert | Embeds texts into the SQLite vector store (RAG) |
-| `rag.query` | Vector Store: Query | Semantic search over the vector store (RAG) |
-
----
-
-## Prerequisites
-
-- [.NET 10 SDK](https://dotnet.microsoft.com/download)
-- **PostgreSQL** (default: `localhost:5432`)
-- **Docker** (optional, to run Redis and/or Postgres in containers)
-- Redis (optional; an in-memory fallback is used if absent)
-
----
-
-## How to Install
-
-### ⚡ Quick Start (Docker Compose)
-
-The easiest way to run the complete FlowSharp stack (PostgreSQL, Redis, Web UI, and Worker) is using Docker Compose:
+Run the stack with Docker Compose:
 
 ```bash
 docker compose up -d --build
 ```
 
-Once all containers are running, navigate to `http://localhost:8080` in your browser.
-* **Default Admin Credentials:** `admin@flowsharp.local` / `Admin!2345`
+Open:
 
----
+```text
+http://localhost:8080
+```
 
-### 💻 Developer Setup (Local Development)
+Default admin account:
 
-If you wish to run the components individually for development purposes:
+```text
+admin@flowsharp.local
+Admin!2345
+```
+
+The default Docker Compose setup uses SQLite for the application database and Redis for cross-process workflow events.
+
+## Local Development
+
+Requirements:
+
+- .NET 10 SDK
+- Docker, optional but useful for Redis and database services
+
+Build:
 
 ```powershell
-# 1) Clone the repository
-git clone https://github.com/FlowSharp/FlowSharp.git
-cd FlowSharp
-
-
-# 2) Start helper services (Redis/Postgres)
-docker compose up -d
-
-# 3) Restore and build
 dotnet restore
 dotnet build
+```
 
-# 4) Apply the database schema (migration)
-dotnet ef database update `
-  --project src/FlowSharp.Infrastructure `
-  --startup-project src/FlowSharp.Web
+Run Web:
 
-# 5) Run Web and Worker in separate terminals
+```powershell
 dotnet run --project src/FlowSharp.Web
+```
+
+Run Worker in another terminal:
+
+```powershell
 dotnet run --project src/FlowSharp.Worker
 ```
 
-> 💡 **Single-process mode:** set `"Worker": { "RunInWebProcess": true }` in `appsettings.json` to run the Worker inside the web app — no separate Worker terminal needed.
+For single-process development, set:
 
-> 💡 **Auto migration:** set `"Database": { "ApplyMigrationsOnStartup": true }` to apply migrations on startup.
-
-The app listens on `https://localhost:7163` and `http://localhost:5094`.
-
----
-
-## Configuration (appsettings.json)
-
-```jsonc
+```json
 {
-  "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=flowsharp_db;Username=postgres;Password=postgres"
-  },
-  "Database": { "ApplyMigrationsOnStartup": false },
-  "Redis": { "ConnectionString": "localhost:6379" },
-  "Worker": { "RunInWebProcess": false },
-
-  // Execution records
-  "Executions": { "SaveData": "All", "MaxCount": 1000, "MaxAgeDays": 30 },
-
-  // Plugin system
-  "Plugins": {
-    "Path": "plugins",
-    "OfficialMarketplaceUrl": "https://github.com/FlowSharp/FlowSharp.plugins"
-  },
-
-  // Security Encryption Key (MUST be set in production)
-  "Security": { "CredentialEncryptionKey": "<strong-random-key>" },
-
-  // First admin user (created only when no users exist)
-  "Seed": {
-    "Enabled": true,
-    "Admin": { "Email": "admin@flowsharp.local", "Password": "Admin!2345" }
+  "Worker": {
+    "RunInWebProcess": true
   }
 }
 ```
 
----
+## Database Support
 
-## Roles and Permissions
+FlowSharp supports these EF Core providers:
 
-Three roles are seeded on startup: **Admin**, **Editor**, **Viewer**.
+- `Sqlite`
+- `Postgres`
+- `SqlServer`
 
-| Permission | Description | Admin | Editor | Viewer |
-|---|---|:--:|:--:|:--:|
-| `workflows.read` | View workflows | ✅ | ✅ | ✅ |
-| `workflows.write` | Edit workflows | ✅ | ✅ | — |
-| `workflows.execute` | Run workflows | ✅ | ✅ | — |
-| `executions.read` | View execution logs | ✅ | ✅ | ✅ |
-| `plugins.manage` | Marketplace / plugin management | ✅ | — | — |
+Default local SQLite connection string:
 
----
-
-## Plugin System (Community Nodes)
-
-The community can add new nodes **without rebuilding** the main application using our **Roslyn-powered hot-loadable** system.
-
-### How it Works
-1. **Each folder** under `plugins/` is a plugin.
-2. All `.cs` files in the folder (including subfolders) are compiled at startup with **Roslyn**.
-3. The produced assembly is loaded into a collectible `AssemblyLoadContext`; its `INodeType`s are added to the node registry.
-
-### Installing from the Marketplace (Admin)
-1. Open **Marketplace** in the left menu (requires `plugins.manage` permission).
-2. Enter a GitHub URL or click "Use official address".
-3. Click **Install**. The plugin is downloaded, compiled, and hot-loaded immediately.
-
----
-
-## Writing a New Node
-
-Example plugin node: `plugins/Sample/HelloNode.cs`:
-
-```csharp
-using System.Text.Json.Nodes;
-using FlowSharp.Application.Nodes;
-using FlowSharp.Domain.Nodes;
-
-namespace Community.Sample;
-
-public sealed class HelloNode : PerItemNodeType
+```json
 {
-    public override NodeDefinition Definition { get; } = new(
-        Key: "community.hello",
-        DisplayName: "Hello (Plugin)",
-        Category: NodeCategory.Core,
-        Kind: NodeKind.Action,
-        Description: "Adds a greeting to the item.",
-        Parameters: [ new NodeParameterDefinition("name", "Name", NodeParameterType.String, DefaultValue: "World") ],
-        Tags: ["community"], Icon: "sparkles", Color: "#9b51e0");
-
-    protected override Task<NodeItem?> ProcessItemAsync(INodeExecutionContext context, NodeItem item, int index)
-    {
-        var name = context.GetString("name", index) ?? "World";
-        var output = (JsonObject)item.Json.DeepClone();
-        output["greeting"] = $"Hello, {name}!";
-        return Task.FromResult<NodeItem?>(NodeItem.From(output));
-    }
+  "Database": {
+    "Provider": "Sqlite",
+    "ApplyMigrationsOnStartup": true
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=App_Data/flowsharp.db"
+  }
 }
 ```
 
----
+See [Configuration](docs/guide/configuration.md) for PostgreSQL, SQL Server, Redis, plugins, credentials, and production settings.
 
-## Webhook and Response (Respond to Webhook)
+## Documentation
 
-- A workflow starting with `webhook.trigger` runs **synchronously** on incoming HTTP requests.
-- Endpoint: `/webhook/{path}` — `path` and `method` are matched from the webhook node parameters.
-
----
+- [Getting Started](docs/guide/getting-started.md)
+- [Architecture](docs/guide/architecture.md)
+- [Configuration](docs/guide/configuration.md)
+- [Roles And Permissions](docs/guide/roles-and-permissions.md)
+- [Built-in Nodes](docs/guide/built-in-nodes.md)
+- [AI Agents](docs/guide/ai-agents.md)
+- [Webhooks](docs/guide/webhooks.md)
+- [Plugin Development](docs/guide/plugin-development.md)
+- [Marketplace](docs/guide/marketplace.md)
 
 ## Project Structure
 
-```
+```text
 src/
-├─ FlowSharp.Web            # Blazor UI, Identity, webhook endpoint, marketplace, plugins/
-├─ FlowSharp.Worker         # BackgroundService that processes jobs from the queue
-├─ FlowSharp.Domain         # Workflow, execution, queue, node, security models
-├─ FlowSharp.Application    # Contracts: INodeType, INodeRegistry, IPluginManager, expressions
-├─ FlowSharp.Infrastructure # EF Core, queue, runner, engine, plugin manager (Roslyn), scheduler
-└─ FlowSharp.Nodes          # All built-in nodes (HTTP, AI, DB, communication, core, transform)
+|-- FlowSharp.Web            Blazor UI, Identity, designer, webhooks, marketplace
+|-- FlowSharp.Worker         Background worker for queued and scheduled jobs
+|-- FlowSharp.Domain         Workflow, execution, queue, credential, and node models
+|-- FlowSharp.Application    Interfaces and application contracts
+|-- FlowSharp.Infrastructure EF Core, workflow engine, queue, plugins, scheduler
+|-- FlowSharp.Nodes          Built-in workflow nodes
 ```
-
----
-
-## Sponsorship & Support
-
-If your company relies on FlowSharp for business-critical automation, we offer several ways to help support the project:
-
-*   **Commercial Support:** Need custom enterprise node development, high-availability deployments, or professional integration assistance? Reach out to us for dedicated support agreements.
-*   **GitHub Sponsors:** Sponsor FlowSharp development directly on GitHub to support our roadmap and unlock premium sponsor benefits.
-*   **Enterprise Plugins:** Access premium enterprise-grade nodes and features designed for high-scale workflows.
-
----
 
 ## License
 
-This project is licensed under the **Elastic License 2.0 (ELv2)**. 
-
-*   **Free for Use:** You are free to run FlowSharp internally for your own personal projects or within your organization.
-*   **No SaaS Reselling:** You cannot offer FlowSharp as a managed, hosted service to third parties.
-*   **Branding & Copyrights:** You must retain all "FlowSharp" branding, copyright notices, and attribution headers.
-
-For more details, see the [LICENSE.md](LICENSE.md) file.
-
----
+FlowSharp is licensed under the **Elastic License 2.0 (ELv2)**. See [LICENSE.md](LICENSE.md).
 
 ## Contributing
 
-We welcome community contributions! To ensure code quality and prevent double work, we follow an **"Issue-Driven Contribution" (Talk First, Code Later)** model.
-
-Please read our [Contributing Guidelines](CONTRIBUTING.md) before making changes to the Core repository.
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.

--- a/README.tr.md
+++ b/README.tr.md
@@ -1,368 +1,154 @@
 # FlowSharp
 
-> 🌐 **Languages:** [English](README.md) · [Türkçe](README.tr.md)
+![FlowSharp workflow automation hero](docs/assets/flowsharp-hero.png)
 
-**C# / .NET 10 ve Blazor** ile geliştirilmiş, kurumsal seviye **workflow otomasyon** platformu. Düğüm tabanlı (node-based) görsel akış tasarımcısı, gerçek çalışan node'lar, AI ajan desteği, zamanlanmış/webhook tetikleyiciler ve **çalışırken yüklenebilen topluluk plugin sistemi** içerir.
+FlowSharp, **C#**, **.NET 10** ve **Blazor** ile geliştirilen node tabanlı bir workflow otomasyon platformudur. Görsel workflow tasarımcısı, çalıştırılabilir otomasyon node'ları, AI ajan desteği, webhook ve zamanlanmış tetikleyiciler, arka plan worker'ları ve çalışma zamanında yüklenebilen C# plugin sistemi içerir.
 
----
+![FlowSharp workflow designer](docs/assets/flowsharp-designer-mockup.png)
 
-## İçindekiler
+## Öne Çıkanlar
 
-- [Özellikler](#özellikler)
-- [Mimari](#mimari)
-- [Kullanılan Kütüphaneler](#kullanılan-kütüphaneler)
-- [Hazır Yüklü Node'lar](#hazır-yüklü-nodelar)
-- [Gereksinimler](#gereksinimler)
-- [Nasıl Kurulur](#nasıl-kurulur)
-- [Yapılandırma (appsettings.json)](#yapılandırma-appsettingsjson)
-- [Roller ve Yetkiler](#roller-ve-yetkiler)
-- [Plugin Sistemi (Topluluk Node'ları)](#plugin-sistemi-topluluk-nodeları)
-- [Yeni Node Yazmak](#yeni-node-yazmak)
-- [Webhook ve Yanıt (Respond to Webhook)](#webhook-ve-yanıt-respond-to-webhook)
-- [Proje Yapısı](#proje-yapısı)
-- [Sponsorluk ve Destek](#sponsorluk-ve-destek)
-- [Lisans](#lisans)
-- [Sorun Giderme](#sorun-giderme)
-- [Katkıda Bulunma](#katkıda-bulunma)
-
----
-
-## Özellikler
-
-- 🎨 **Görsel Workflow Tasarımcısı** — node ekleme, bağlama, kategori/arama filtresi, parametre düzenleme.
-- ⚡ **Gerçek Çalışan Node'lar** — HTTP, e-posta (SMTP/IMAP), PostgreSQL, Slack/Telegram/Discord, mantık (IF/Switch/Filter/Merge), veri dönüşümü ve JavaScript (Jint) kodu.
-- 🤖 **AI Agent** — Semantic Kernel üzerinden OpenAI, Azure OpenAI, Anthropic, Gemini, Groq, Mistral, Cohere, HuggingFace, OpenRouter ve Ollama; araç (tool) bağlama desteği.
-- ⏰ **Tetikleyiciler** — Manuel, Cron zamanlı, Webhook (senkron yanıt dönebilen), IMAP e-posta ve Chat.
-- 🔌 **Canlı Plugin Sistemi** — `plugins/` klasörüne bırakılan ham `.cs` dosyaları **Roslyn** ile çalışırken derlenir; ana uygulama yeniden derlenmeden node eklenir.
-- 🛒 **Admin Marketplace** — GitHub deposundan plugin indir, kur, yeniden yükle, kaldır.
-- 🔐 **Kimlik & Yetki** — ASP.NET Core Identity + rol/permission policy altyapısı.
-- 📡 **Gerçek Zamanlı** — SignalR ile canlı node çalışma durumu (Redis veya in-memory fallback).
-- 🧮 **Expression Motoru** — `{{ $json.alan }}`, `{{ $node["Ad"].json }}`, `{{ $now }}` vb.; tasarımcıda **canlı doğrulama** (yeşil/kırmızı).
-- 📝 **Loglama** — Serilog ile konsol ve günlük dosyaları.
-
----
-
-## Mimari
-
-| Katman | Teknoloji |
-|---|---|
-| UI | Blazor Web App (interactive server render) |
-| Backend | ASP.NET Core (.NET 10) |
-| Gerçek zamanlı | SignalR + Redis (ya da in-memory) |
-| Veritabanı | PostgreSQL |
-| ORM | EF Core + JSONB workflow tanımı |
-| Kimlik | ASP.NET Core Identity |
-| Yetki | rol/permission policy (`AppPermissions`) |
-| Kuyruk | PostgreSQL tabanlı `workflow_jobs` tablosu |
-| Worker | ayrı `BackgroundService` projesi |
-| Plugin | Roslyn runtime derleme + `AssemblyLoadContext` |
-| AI | Microsoft Semantic Kernel |
-| Loglama | Serilog (console + file) |
-
----
+- Node paleti, bağlantılar, parametreler ve çalışma durumları olan görsel workflow tasarımcısı.
+- HTTP, e-posta, PostgreSQL, mantık, veri dönüşümü, JavaScript, iletişim servisleri ve AI için çalıştırılabilir node'lar.
+- Semantic Kernel tabanlı, model ve araç alt-node'ları destekleyen AI ajanları.
+- Webhook, manuel, zamanlanmış, chat, IMAP, workflow ve hata tetikleyicileri.
+- Runtime plugin sistemi: C# kaynak dosyalarını `plugins/` klasörüne bırakıp uygulamayı yeniden derlemeden yeni node yükleme.
+- ASP.NET Core Identity, rol/permission policy altyapısı, şifreli credential saklama, SignalR canlı olaylar ve Serilog logları.
 
 ## Kullanılan Kütüphaneler
-
-Aşağıdaki NuGet paketleri projede kullanılır:
 
 | Paket | Sürüm | Kullanım |
 |---|---|---|
 | `Microsoft.SemanticKernel` | 1.77.0 | AI Agent ve sohbet modelleri |
-| `MailKit` | 4.17.0 | SMTP gönderme ve IMAP okuma |
-| `Jint` | 4.9.2 | Code node — sandbox'lı JavaScript |
-| `CsvHelper` | 33.0.1 | CSV node — CSV oku/yaz |
-| `AngleSharp` | 1.1.2 | HTML Extract node — CSS selector ile ayrıştırma |
-| `ClosedXML` | 0.104.2 | Spreadsheet node — Excel (.xlsx) okuma |
-| `Microsoft.Data.Sqlite` | 10.0.0 | RAG — SQLite vektör deposu (workspace başına) |
-| `SmartComponents.LocalEmbeddings` | 0.1.0-preview10148 | RAG — yerel/in-process embedding (gömülü ONNX) |
+| `MudBlazor` | 9.5.0 | UI bileşenleri |
+| `MailKit` | 4.17.0 | SMTP gönderimi ve IMAP okuma |
+| `Jint` | 4.9.2 | Code node - sandbox JavaScript |
+| `CsvHelper` | 33.0.1 | CSV node - CSV okuma/yazma |
+| `AngleSharp` | 1.1.2 | HTML Extract node - CSS selector ayrıştırma |
+| `ClosedXML` | 0.104.2 | Spreadsheet node - Excel (.xlsx) okuma |
+| `Microsoft.Data.Sqlite` | 10.0.0 | RAG - SQLite vektör deposu |
+| `SmartComponents.LocalEmbeddings` | 0.1.0-preview10148 | RAG - yerel/in-process embedding |
 | `Npgsql.EntityFrameworkCore.PostgreSQL` | 10.0.2 | PostgreSQL + EF Core |
+| `Microsoft.EntityFrameworkCore.SqlServer` | 10.0.8 | SQL Server + EF Core |
+| `Microsoft.EntityFrameworkCore.Sqlite` | 10.0.8 | SQLite + EF Core |
 | `Microsoft.EntityFrameworkCore.Design` / `.Tools` | 10.0.8 | Migration araçları |
-| `Microsoft.AspNetCore.Identity.EntityFrameworkCore` | 10.0.8 | Kimlik depolama |
-| `Microsoft.CodeAnalysis.CSharp` (+ Workspaces) | 5.3.0 | **Roslyn** — plugin runtime derleme |
-| `StackExchange.Redis` | 2.13.17 | SignalR olay yayını (çok-process) |
-| `Cronos` | 0.13.0 | Cron ifadesi çözümleme (zamanlayıcı) |
-| `Serilog.AspNetCore` / `Sinks.Console` / `Sinks.File` | 10.0.0 / 6.1.1 / 7.0.0 | Loglama |
-| `Microsoft.Extensions.Hosting` | 10.0.8 | Worker host altyapısı |
+| `Microsoft.AspNetCore.Identity.EntityFrameworkCore` | 10.0.8 | Identity depolama |
+| `Microsoft.CodeAnalysis.CSharp` / Workspaces | 5.3.0 | Roslyn runtime plugin derleme |
+| `StackExchange.Redis` | 2.13.17 | Workflow olay backplane'i |
+| `Cronos` | 0.13.0 | Cron ifadesi ayrıştırma |
+| `Serilog.AspNetCore` / Sinks | 10.0.0 / 6.1.1 / 7.0.0 | Loglama |
 
----
+## Hızlı Başlangıç
 
-## Hazır Yüklü Node'lar
-
-Tüm node'lar `INodeType` implementasyonu olarak **otomatik keşfedilir** ve palette'te kategorilerine göre görünür.
-
-### Tetikleyiciler (Trigger)
-| Anahtar | Ad | Açıklama |
-|---|---|---|
-| `manual.trigger` | Manual Trigger | Akışı elle başlatır |
-| `schedule.trigger` | Schedule Trigger | Cron ifadesine göre periyodik çalışır |
-| `webhook.trigger` | Webhook | Gelen HTTP isteğiyle başlar (senkron yanıt verebilir) |
-| `email.imap.trigger` | Email Trigger (IMAP) | Gelen kutusuna yeni e-posta düşünce tetikler |
-| `chat.trigger` | AI Chat UI | Sohbet arayüzünden tetikler |
-| `flow.executeWorkflowTrigger` | Execute Workflow Trigger | Başka bir workflow tarafından çağrılınca başlar |
-| `error.trigger` | Error Trigger | Bir workflow hata verince çalışır |
-
-### Çekirdek / Mantık (Core)
-| Anahtar | Ad | Açıklama |
-|---|---|---|
-| `if.condition` | IF | Koşula göre true/false dallandırma |
-| `switch.condition` | Switch | Çoklu kola dallandırma |
-| `filter.items` | Filter | Koşula uyan item'ları geçirir |
-| `merge.items` | Merge | Birden çok girişi birleştirir |
-| `set.fields` | Set | Alan ekler/değiştirir |
-| `no.op` | No Operation | Veriyi olduğu gibi geçirir |
-| `code.javascript` | Code | Sandbox'lı JavaScript (Jint) çalıştırır |
-| `flow.wait` | Wait | Akışı belirtilen süre kadar bekletir |
-| `flow.stopAndError` | Stop And Error | Akışı özel hata mesajıyla durdurur |
-| `flow.executeWorkflow` | Execute Workflow | Bir alt-workflow'u çalıştırır ve çıktısını döner |
-| `flow.loopOverItems` | Loop Over Items | Item'ları parti parti (batch) işler; `loop`/`done` çıkışları |
-
-### Veri / Dönüşüm (Data)
-| Anahtar | Ad | Açıklama |
-|---|---|---|
-| `sort.items` | Sort | Bir alana göre sıralar |
-| `limit.items` | Limit | Maksimum item sayısını sınırlar |
-| `aggregate.items` | Aggregate | Tüm item'ları tek item'da toplar |
-| `split.out` | Split Out | Bir dizi alanını ayrı item'lara böler |
-| `datetime.action` | Date & Time | Tarih/saat üretir veya biçimlendirir |
-| `transform.crypto` | Crypto | Hash / HMAC / Base64 işlemleri |
-| `transform.csv` | CSV | Item'ları CSV'ye çevirir veya CSV'yi item'lara ayrıştırır |
-| `transform.htmlExtract` | HTML Extract | HTML'den CSS selector ile veri çıkarır |
-| `transform.spreadsheet` | Spreadsheet | Yüklenen Excel/CSV dosyasını okur; her satır bir item olur |
-
-### HTTP
-| Anahtar | Ad | Açıklama |
-|---|---|---|
-| `http.request` | HTTP Request | Metot seçilebilir tam REST isteği |
-| `http.get` / `http.post` / `http.put` / `http.patch` / `http.delete` | HTTP GET/POST/... | Sabit metotlu istekler |
-| `webhook.response` | Respond to Webhook | Webhook çağıranına özel yanıt döner |
-
-### Veritabanı (Database)
-| Anahtar | Ad | Açıklama |
-|---|---|---|
-| `postgres.query` | Postgres | SQL sorgusu çalıştırır (select/execute) |
-
-### İletişim (Communication)
-| Anahtar | Ad | Açıklama |
-|---|---|---|
-| `email.send` | Send Email | SMTP ile e-posta gönderir (MailKit) |
-| `telegram.message` | Telegram | Telegram'a mesaj gönderir |
-| `slack.message` | Slack | Slack kanalına mesaj gönderir |
-| `discord.message` | Discord | Discord webhook'una mesaj gönderir |
-
-### AI
-| Anahtar | Ad | Açıklama |
-|---|---|---|
-| `ai.agent` | AI Agent | Araç çağırabilen AI ajanı |
-| `openai.chat` / `azureopenai.chat` / `anthropic.chat` / `gemini.chat` / `groq.chat` / `mistral.chat` / `cohere.chat` / `huggingface.chat` / `openrouter.chat` / `ollama.chat` | *Provider* Chat | Doğrudan sohbet tamamlama |
-| `*.chatmodel` | *Provider* Chat Model | AI Agent'a bağlanan model alt-node'u |
-| `tool.httpRequest` | HTTP Request Tool | Ajana HTTP aracı |
-| `tool.calculator` | Calculator | Ajana hesap makinesi aracı |
-| `rag.insert` | Vector Store: Insert | Metinleri embedding'leyip SQLite vektör deposuna ekler (RAG) |
-| `rag.query` | Vector Store: Query | Vektör deposunda anlamsal arama yapar (RAG) |
-
----
-
-## Gereksinimler
-
-- [.NET 10 SDK](https://dotnet.microsoft.com/download)
-- **PostgreSQL** (varsayılan: `localhost:5432`)
-- **Docker** (Redis ve/veya Postgres'i container ile çalıştırmak için — opsiyonel)
-- Redis (opsiyonel; yoksa in-memory fallback devreye girer)
-
----
-
-## Nasıl Kurulur
-
-### ⚡ Hızlı Kurulum (Docker Compose)
-
-Tüm FlowSharp stack'ini (PostgreSQL, Redis, Web UI ve Worker) tek bir komutla ayağa kaldırmak için en kolay yol Docker Compose kullanmaktır:
+Docker Compose ile stack'i çalıştırın:
 
 ```bash
 docker compose up -d --build
 ```
 
-Konteynerler çalışmaya başladıktan sonra tarayıcınızdan `http://localhost:8080` adresine gidebilirsiniz.
-* **Varsayılan Admin Bilgileri:** `admin@flowsharp.local` / `Admin!2345`
+Tarayıcıdan açın:
 
----
+```text
+http://localhost:8080
+```
 
-### 💻 Geliştirici Kurulumu (Lokal Çalıştırma)
+Varsayılan admin hesabı:
 
-Bileşenleri geliştirme amaçlı olarak yerel makinenizde ayrı ayrı çalıştırmak isterseniz:
+```text
+admin@flowsharp.local
+Admin!2345
+```
+
+Varsayılan Docker Compose kurulumu uygulama veritabanı için SQLite, process'ler arası workflow olayları için Redis kullanır.
+
+## Lokal Geliştirme
+
+Gereksinimler:
+
+- .NET 10 SDK
+- Docker, Redis ve veritabanı servisleri için opsiyonel ama kullanışlıdır
+
+Derleme:
 
 ```powershell
-# 1) Depoyu klonla
-git clone https://github.com/FlowSharp/FlowSharp.git
-cd FlowSharp
-
-# 2) Yardımcı servisleri başlat (Redis/Postgres)
-docker compose up -d
-
-# 3) Paketleri geri yükle ve derle
 dotnet restore
 dotnet build
+```
 
-# 4) Veritabanı şemasını uygula (migration)
-dotnet ef database update `
-  --project src/FlowSharp.Infrastructure `
-  --startup-project src/FlowSharp.Web
+Web uygulamasını çalıştırma:
 
-# 5) Web ve Worker'ı ayrı terminallerde çalıştır
+```powershell
 dotnet run --project src/FlowSharp.Web
+```
+
+Worker'ı ayrı terminalde çalıştırma:
+
+```powershell
 dotnet run --project src/FlowSharp.Worker
 ```
 
-> 💡 **Tek process modu:** `appsettings.json` içinde `"Worker": { "RunInWebProcess": true }` yaparsanız Worker, web uygulamasının içinde çalışır; ayrı terminal/Worker gerekmez.
+Tek process geliştirme modu için:
 
-> 💡 **Otomatik migration:** `"Database": { "ApplyMigrationsOnStartup": true }` ile açılışta migration otomatik uygulanır.
-
-Uygulama `https://localhost:7163` ve `http://localhost:5094` üzerinde dinler.
-
----
-
-## Yapılandırma (appsettings.json)
-
-```jsonc
+```json
 {
-  "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=flowsharp_db;Username=postgres;Password=Postgres"
-  },
-  "Database": { "ApplyMigrationsOnStartup": false },
-  "Redis": { "ConnectionString": "localhost:6379" },
-  "Worker": { "RunInWebProcess": false },
-
-  // Çalışma kayıtları
-  "Executions": { "SaveData": "All", "MaxCount": 1000, "MaxAgeDays": 30 },
-
-  // Plugin sistemi
-  "Plugins": {
-    "Path": "plugins",
-    "OfficialMarketplaceUrl": "https://github.com/FlowSharp/FlowSharp.plugins"
-  },
-
-  // Üretimde MUTLAKA ayarlayın — credential şifreleme anahtarı
-  "Security": { "CredentialEncryptionKey": "<güçlü-rastgele-anahtar>" },
-
-  // İlk admin kullanıcısı (yalnız hiç kullanıcı yoksa oluşturulur)
-  "Seed": {
-    "Enabled": true,
-    "Admin": { "Email": "admin@flowsharp.local", "Password": "Admin!2345" }
+  "Worker": {
+    "RunInWebProcess": true
   }
 }
 ```
 
----
+## Veritabanı Desteği
 
-## Roller ve Yetkiler
+FlowSharp şu EF Core provider'larını destekler:
 
-Açılışta üç rol seed edilir: **Admin**, **Editor**, **Viewer**.
+- `Sqlite`
+- `Postgres`
+- `SqlServer`
 
-| Permission | Açıklama | Admin | Editor | Viewer |
-|---|---|:--:|:--:|:--:|
-| `workflows.read` | Workflow görüntüleme | ✅ | ✅ | ✅ |
-| `workflows.write` | Workflow düzenleme | ✅ | ✅ | — |
-| `workflows.execute` | Workflow çalıştırma | ✅ | ✅ | — |
-| `executions.read` | Çalışma kayıtları | ✅ | ✅ | ✅ |
-| `plugins.manage` | Marketplace / plugin yönetimi | ✅ | — | — |
+Varsayılan lokal SQLite connection string:
 
----
-
-## Plugin Sistemi (Topluluk Node'ları)
-
-Topluluk, ana uygulamayı yeniden derlemeden **Roslyn destekli dinamik yükleme** sistemimiz ile yeni node ekleyebilir.
-
-### Nasıl Çalışır
-1. `plugins/` altındaki **her klasör** bir plugin'dir.
-2. Klasördeki tüm `.cs` dosyaları (alt klasörler dahil) açılışta **Roslyn** ile derlenir.
-3. Üretilen assembly collectible bir `AssemblyLoadContext`'e yüklenir; içindeki `INodeType` ahadları node kaydına eklenir.
-
-### Marketplace'ten Kurulum (Admin)
-1. Sol menüden **Marketplace**'i açın (`plugins.manage` yetkisi gerekir).
-2. GitHub URL'sini girin veya "Resmi adresi kullan" seçeneğine tıklayın.
-3. **Kur** butonuna basın. Eklenti indirilir, derlenir ve anında canlı olarak yüklenir.
-
----
-
-## Yeni Node Yazmak
-
-Örnek bir plugin düğümü: `plugins/Sample/HelloNode.cs`:
-
-```csharp
-using System.Text.Json.Nodes;
-using FlowSharp.Application.Nodes;
-using FlowSharp.Domain.Nodes;
-
-namespace Community.Sample;
-
-public sealed class HelloNode : PerItemNodeType
+```json
 {
-    public override NodeDefinition Definition { get; } = new(
-        Key: "community.hello",
-        DisplayName: "Hello (Plugin)",
-        Category: NodeCategory.Core,
-        Kind: NodeKind.Action,
-        Description: "Item'a selam ekler.",
-        Parameters: [ new NodeParameterDefinition("name", "Name", NodeParameterType.String, DefaultValue: "Dunya") ],
-        Tags: ["community"], Icon: "sparkles", Color: "#9b51e0");
-
-    protected override Task<NodeItem?> ProcessItemAsync(INodeExecutionContext context, NodeItem item, int index)
-    {
-        var name = context.GetString("name", index) ?? "Dunya";
-        var output = (JsonObject)item.Json.DeepClone();
-        output["greeting"] = $"Merhaba, {name}!";
-        return Task.FromResult<NodeItem?>(NodeItem.From(output));
-    }
+  "Database": {
+    "Provider": "Sqlite",
+    "ApplyMigrationsOnStartup": true
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=App_Data/flowsharp.db"
+  }
 }
 ```
 
----
+PostgreSQL, SQL Server, Redis, plugin, credential ve production ayarları için [Configuration](docs/guide/configuration.md) dokümanına bakın.
 
-## Webhook ve Yanıt (Respond to Webhook)
+## Dokümantasyon
 
-- `webhook.trigger` ile başlayan bir workflow, gelen HTTP isteğinde **senkron** çalışır.
-- Endpoint: `/webhook/{path}` — `path` ve `method` webhook node parametrelerinden eşlenir.
-
----
+- [Getting Started](docs/guide/getting-started.md)
+- [Architecture](docs/guide/architecture.md)
+- [Configuration](docs/guide/configuration.md)
+- [Roles And Permissions](docs/guide/roles-and-permissions.md)
+- [Built-in Nodes](docs/guide/built-in-nodes.md)
+- [AI Agents](docs/guide/ai-agents.md)
+- [Webhooks](docs/guide/webhooks.md)
+- [Plugin Development](docs/guide/plugin-development.md)
+- [Marketplace](docs/guide/marketplace.md)
 
 ## Proje Yapısı
 
-```
+```text
 src/
-├─ FlowSharp.Web            # Blazor UI, Identity, webhook endpoint, marketplace, plugins/
-├─ FlowSharp.Worker         # Kuyruktan job işleyen BackgroundService
-├─ FlowSharp.Domain         # Workflow, execution, queue, node, security modelleri
-├─ FlowSharp.Application    # Sözleşmeler: INodeType, INodeRegistry, IPluginManager, expression
-├─ FlowSharp.Infrastructure # EF Core, kuyruk, runner, motor, plugin manager (Roslyn), scheduler
-└─ FlowSharp.Nodes          # Tüm hazır node'lar (HTTP, AI, DB, iletişim, core, transform)
+|-- FlowSharp.Web            Blazor UI, Identity, designer, webhooks, marketplace
+|-- FlowSharp.Worker         Kuyruktaki ve zamanlanmış işleri çalışan arka plan worker'ı
+|-- FlowSharp.Domain         Workflow, execution, queue, credential ve node modelleri
+|-- FlowSharp.Application    Interface'ler ve application contract'ları
+|-- FlowSharp.Infrastructure EF Core, workflow engine, queue, plugins, scheduler
+|-- FlowSharp.Nodes          Yerleşik workflow node'ları
 ```
-
----
-
-## Sponsorluk ve Destek
-
-Şirketiniz iş kritik otomasyon süreçleri için FlowSharp kullanıyorsa, projeyi desteklemenin yolları:
-
-*   **Kurumsal Danışmanlık:** Özel kurumsal eklenti (node) geliştirme, yüksek kullanılabilirlikli kurulumlar veya profesyonel entegrasyon yardımı mı gerekiyor? Profesyonel destek anlaşmaları için bizimle iletişime geçebilirsiniz.
-*   **GitHub Sponsors:** FlowSharp geliştirmesini doğrudan GitHub üzerinden destekleyerek yol haritamıza katkıda bulunabilir ve sponsor ayrıcalıklarından faydalanabilirsiniz.
-*   **Premium Eklentiler:** Büyük ölçekli ve kurumsal süreçler için özel olarak tasarlanmış premium işlevlere sahip eklentilere erişebilirsiniz.
-
----
 
 ## Lisans
 
-Bu proje **Elastic License 2.0 (ELv2)** ile lisanslanmıştır.
+FlowSharp **Elastic License 2.0 (ELv2)** ile lisanslanmıştır. Detaylar için [LICENSE.md](LICENSE.md) dosyasına bakın.
 
-*   **Kullanım Serbestliği:** FlowSharp'ı bireysel projelerinizde veya kendi organizasyonunuz/şirketiniz içinde ücretsiz olarak çalıştırabilirsiniz.
-*   **SaaS Satış Yasağı:** Projeyi üçüncü şahıslara ücretli/ücretsiz bir bulut/SaaS servisi olarak kiralayamaz veya satamazsınız.
-*   **Telif Hakları ve Marka:** Projedeki tüm "FlowSharp" markalamasını, lisans başlıklarını ve telif bildirimlerini aynen korumanız zorunludur.
+## Katkı
 
-Detaylar için [LICENSE.md](LICENSE.md) dosyasına göz atabilirsiniz.
-
----
-
-## Katkıda Bulunma
-
-Topluluk katkılarını memnuniyetle karşılıyoruz! Kod kalitesini korumak ve mükerrer çalışmaları önlemek için **"Önce Konuş, Sonra Kodla" (Issue Bağımlılığı)** modelini uyguluyoruz.
-
-Core (çekirdek) repoda değişiklik yapmadan önce lütfen [Katkı Sağlama Kılavuzumuzu](CONTRIBUTING.tr.md) okuyun.
-
+Pull request açmadan önce lütfen [CONTRIBUTING.tr.md](CONTRIBUTING.tr.md) dosyasını okuyun.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,8 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - ASPNETCORE_HTTP_PORTS=8080
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=flowsharp_db;Username=postgres;Password=postgres
+      - Database__Provider=Sqlite
+      - ConnectionStrings__DefaultConnection=Data Source=/app/App_Data/flowsharp.db
       - Redis__ConnectionString=redis:6379
       - Database__ApplyMigrationsOnStartup=true
       - Security__CredentialEncryptionKey=TXlTdXBlclNlY3JldEVuY3J5cHRpb25LZXkxMjM0NTY=
@@ -41,8 +42,8 @@ services:
       - flowsharp_plugins:/app/plugins
       - flowsharp_logs:/app/logs
       - flowsharp_rag_db:/app/rag_db
+      - flowsharp_sqlite_data:/app/App_Data
     depends_on:
-      - postgres
       - redis
 
   flowsharp-worker:
@@ -55,14 +56,15 @@ services:
       target: worker
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=flowsharp_db;Username=postgres;Password=postgres
+      - Database__Provider=Sqlite
+      - ConnectionStrings__DefaultConnection=Data Source=/app/App_Data/flowsharp.db
       - Redis__ConnectionString=redis:6379
       - Security__CredentialEncryptionKey=TXlTdXBlclNlY3JldEVuY3J5cHRpb25LZXkxMjM0NTY=
     volumes:
       - flowsharp_logs:/app/logs
       - flowsharp_rag_db:/app/rag_db
+      - flowsharp_sqlite_data:/app/App_Data
     depends_on:
-      - postgres
       - redis
 
 volumes:
@@ -70,3 +72,4 @@ volumes:
   flowsharp_plugins:
   flowsharp_logs:
   flowsharp_rag_db:
+  flowsharp_sqlite_data:

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -23,7 +23,7 @@ src/
 | **UI** | Blazor Web App (Interactive Server) | Live dashboard, visual designer canvas. |
 | **Backend** | ASP.NET Core (.NET 10) | Host API, websocket connections. |
 | **Realtime Updates** | SignalR + Redis | Updates node status execution live in the browser. |
-| **Database** | PostgreSQL + EF Core | Stores workflows (JSONB definitions) and executions. |
+| **Database** | PostgreSQL, SQL Server, or SQLite + EF Core | Stores workflows, JSON definitions, executions, and queue jobs. |
 | **Queue** | DB-backed queue | Uses PostgreSQL-backed `workflow_jobs` table for reliable job processing. |
 | **Worker** | Background Service | Separate daemon consuming jobs from the database queue. |
 | **Plugins** | Roslyn C# Compiler | Hot-compiles C# source code files and loads assemblies dynamically. |

--- a/docs/guide/built-in-nodes.md
+++ b/docs/guide/built-in-nodes.md
@@ -1,0 +1,93 @@
+# Built-in Nodes
+
+FlowSharp discovers built-in nodes automatically from `INodeType` implementations. Nodes appear in the designer palette grouped by category.
+
+## Triggers
+
+| Key | Name | Description |
+|---|---|---|
+| `manual.trigger` | Manual Trigger | Starts a workflow manually. |
+| `schedule.trigger` | Schedule Trigger | Runs periodically from a cron expression. |
+| `webhook.trigger` | Webhook | Starts from an incoming HTTP request. |
+| `email.imap.trigger` | Email Trigger (IMAP) | Starts when new email arrives. |
+| `chat.trigger` | AI Chat UI | Starts from the chat interface. |
+| `flow.executeWorkflowTrigger` | Execute Workflow Trigger | Starts when called by another workflow. |
+| `error.trigger` | Error Trigger | Runs when a workflow fails. |
+
+## Core And Logic
+
+| Key | Name | Description |
+|---|---|---|
+| `if.condition` | IF | Branches true or false from a condition. |
+| `switch.condition` | Switch | Branches to multiple outputs. |
+| `filter.items` | Filter | Passes items matching a condition. |
+| `merge.items` | Merge | Combines multiple inputs. |
+| `set.fields` | Set | Adds or updates item fields. |
+| `no.op` | No Operation | Passes data through unchanged. |
+| `code.javascript` | Code | Runs sandboxed JavaScript with Jint. |
+| `flow.wait` | Wait | Pauses the workflow. |
+| `flow.stopAndError` | Stop And Error | Stops the workflow with a custom error. |
+| `flow.executeWorkflow` | Execute Workflow | Runs another workflow and returns its output. |
+| `flow.loopOverItems` | Loop Over Items | Processes items in batches. |
+
+## Data Transform
+
+| Key | Name | Description |
+|---|---|---|
+| `sort.items` | Sort | Sorts items by a field. |
+| `limit.items` | Limit | Caps item count. |
+| `aggregate.items` | Aggregate | Collapses items into one item. |
+| `split.out` | Split Out | Splits an array field into separate items. |
+| `datetime.action` | Date & Time | Produces or formats date/time values. |
+| `transform.crypto` | Crypto | Hash, HMAC, and Base64 operations. |
+| `transform.csv` | CSV | Converts items to CSV or parses CSV into items. |
+| `transform.htmlExtract` | HTML Extract | Extracts data from HTML with CSS selectors. |
+| `transform.spreadsheet` | Spreadsheet | Reads Excel or CSV data. |
+
+## HTTP
+
+| Key | Name | Description |
+|---|---|---|
+| `http.request` | HTTP Request | Full REST request with selectable method. |
+| `http.get` | HTTP GET | Fixed GET request. |
+| `http.post` | HTTP POST | Fixed POST request. |
+| `http.put` | HTTP PUT | Fixed PUT request. |
+| `http.patch` | HTTP PATCH | Fixed PATCH request. |
+| `http.delete` | HTTP DELETE | Fixed DELETE request. |
+| `webhook.response` | Respond to Webhook | Returns a custom response to the webhook caller. |
+
+## Database
+
+| Key | Name | Description |
+|---|---|---|
+| `postgres.query` | Postgres | Runs PostgreSQL select or execute queries. |
+
+## Communication
+
+| Key | Name | Description |
+|---|---|---|
+| `email.send` | Send Email | Sends email over SMTP. |
+| `telegram.message` | Telegram | Sends a Telegram message. |
+| `slack.message` | Slack | Sends a Slack message. |
+| `discord.message` | Discord | Sends to a Discord webhook. |
+
+## AI
+
+| Key | Name | Description |
+|---|---|---|
+| `ai.agent` | AI Agent | Tool-calling AI agent. |
+| `openai.chat` | OpenAI Chat | Direct OpenAI chat completion. |
+| `azureopenai.chat` | Azure OpenAI Chat | Direct Azure OpenAI chat completion. |
+| `anthropic.chat` | Anthropic Chat | Direct Anthropic chat completion. |
+| `gemini.chat` | Gemini Chat | Direct Gemini chat completion. |
+| `groq.chat` | Groq Chat | Direct Groq chat completion. |
+| `mistral.chat` | Mistral Chat | Direct Mistral chat completion. |
+| `cohere.chat` | Cohere Chat | Direct Cohere chat completion. |
+| `huggingface.chat` | HuggingFace Chat | Direct HuggingFace chat completion. |
+| `openrouter.chat` | OpenRouter Chat | Direct OpenRouter chat completion. |
+| `ollama.chat` | Ollama Chat | Direct Ollama chat completion. |
+| `*.chatmodel` | Provider Chat Model | Model sub-node for AI Agent. |
+| `tool.httpRequest` | HTTP Request Tool | HTTP tool for AI Agent. |
+| `tool.calculator` | Calculator | Calculator tool for AI Agent. |
+| `rag.insert` | Vector Store: Insert | Embeds text into the SQLite vector store. |
+| `rag.query` | Vector Store: Query | Semantic search over the vector store. |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -12,6 +12,7 @@ Below is the standard configuration template:
     "DefaultConnection": "Host=localhost;Port=5432;Database=flowsharp_db;Username=postgres;Password=Postgres"
   },
   "Database": {
+    "Provider": "Postgres",
     "ApplyMigrationsOnStartup": false
   },
   "Redis": {
@@ -31,3 +32,39 @@ Below is the standard configuration template:
 
 *   **`Worker:RunInWebProcess`**: When set to `true`, the background job runner processes jobs inside the web application context (single-process mode). Set to `false` for high-performance multi-process setups where a separate worker process handles the load.
 *   **`Plugins:OfficialMarketplaceUrl`**: Points to the GitHub repository hosting community plugins. FlowSharp uses this URL to fetch, download, and dynamically hot-load node plugins.
+
+## Database Providers
+
+Set `Database:Provider` to one of:
+
+*   **`Postgres`**: Default production provider. Uses the existing EF Core migrations.
+*   **`SqlServer`**: Uses SQL Server via EF Core. On startup, FlowSharp creates the schema when migrations are enabled.
+*   **`Sqlite`**: Local and single-node friendly provider. On startup, FlowSharp creates the schema when migrations are enabled.
+
+### SQL Server
+
+```jsonc
+{
+  "Database": {
+    "Provider": "SqlServer",
+    "ApplyMigrationsOnStartup": true
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=FlowSharpDb;User Id=sa;Password=Your_password123;TrustServerCertificate=True"
+  }
+}
+```
+
+### SQLite
+
+```jsonc
+{
+  "Database": {
+    "Provider": "Sqlite",
+    "ApplyMigrationsOnStartup": true
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=App_Data/flowsharp.db"
+  }
+}
+```

--- a/docs/guide/roles-and-permissions.md
+++ b/docs/guide/roles-and-permissions.md
@@ -1,0 +1,72 @@
+# Roles And Permissions
+
+FlowSharp uses ASP.NET Core Identity roles plus permission claims. Each permission is registered as an authorization policy at startup, and policies require a `permission` claim with the same value.
+
+## Seeded Roles
+
+FlowSharp seeds three roles on startup:
+
+| Role | Purpose |
+|---|---|
+| `Admin` | Full access to workflows, executions, and plugin management. |
+| `Editor` | Can create, edit, and execute workflows. |
+| `Viewer` | Can view workflows and execution history. |
+
+## Permission Matrix
+
+| Permission | Description | Admin | Editor | Viewer |
+|---|---|:---:|:---:|:---:|
+| `workflows.read` | View workflow list and workflow details. | Yes | Yes | Yes |
+| `workflows.write` | Create, edit, and save workflows and credentials. | Yes | Yes | No |
+| `workflows.execute` | Run workflows from the UI. | Yes | Yes | No |
+| `executions.read` | View workflow execution history and logs. | Yes | Yes | Yes |
+| `plugins.manage` | Access marketplace and manage plugins. | Yes | No | No |
+
+## Where Permissions Are Defined
+
+Permissions live in:
+
+```text
+src/FlowSharp.Domain/Security/AppPermissions.cs
+```
+
+Role-to-permission seeding lives in:
+
+```text
+src/FlowSharp.Infrastructure/Identity/IdentitySeeder.cs
+```
+
+Authorization policies are registered during web startup:
+
+```text
+src/FlowSharp.Web/Program.cs
+```
+
+## Protected Areas
+
+| Area | Required Permission |
+|---|---|
+| Workflows page | `workflows.read` |
+| Workflow designer | `workflows.write` |
+| Credentials page | `workflows.write` |
+| Executions page | `executions.read` |
+| Marketplace page | `plugins.manage` |
+| Marketplace navigation links | `plugins.manage` |
+
+## First Admin User
+
+When seeding is enabled and no users exist, FlowSharp creates the first admin user from configuration:
+
+```json
+{
+  "Seed": {
+    "Enabled": true,
+    "Admin": {
+      "Email": "admin@flowsharp.local",
+      "Password": "Admin!2345"
+    }
+  }
+}
+```
+
+The first user is assigned to the `Admin` role.

--- a/src/FlowSharp.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/FlowSharp.Infrastructure/Data/ApplicationDbContext.cs
@@ -1,5 +1,9 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using FlowSharp.Domain.Credentials;
 using FlowSharp.Domain.Queue;
 using FlowSharp.Domain.Triggers;
@@ -23,13 +27,15 @@ public sealed class ApplicationDbContext(DbContextOptions<ApplicationDbContext> 
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
+        var jsonColumnType = GetJsonColumnType();
+        var isSqlite = Database.ProviderName == "Microsoft.EntityFrameworkCore.Sqlite";
 
         builder.Entity<Workflow>(entity =>
         {
             entity.ToTable("workflows");
             entity.Property(workflow => workflow.Name).HasMaxLength(200).IsRequired();
             entity.Property(workflow => workflow.Description).HasMaxLength(1000);
-            entity.Property(workflow => workflow.Definition).HasColumnType("jsonb");
+            entity.Property(workflow => workflow.Definition).ConfigureJsonDocument(jsonColumnType);
             entity.HasMany(workflow => workflow.Executions)
                 .WithOne(execution => execution.Workflow)
                 .HasForeignKey(execution => execution.WorkflowId)
@@ -39,8 +45,8 @@ public sealed class ApplicationDbContext(DbContextOptions<ApplicationDbContext> 
         builder.Entity<WorkflowExecution>(entity =>
         {
             entity.ToTable("workflow_executions");
-            entity.Property(execution => execution.Input).HasColumnType("jsonb");
-            entity.Property(execution => execution.Output).HasColumnType("jsonb");
+            entity.Property(execution => execution.Input).ConfigureJsonDocument(jsonColumnType);
+            entity.Property(execution => execution.Output).ConfigureJsonDocument(jsonColumnType);
             entity.Property(execution => execution.Error).HasMaxLength(4000);
             entity.HasIndex(execution => new { execution.WorkflowId, execution.Status });
         });
@@ -48,7 +54,7 @@ public sealed class ApplicationDbContext(DbContextOptions<ApplicationDbContext> 
         builder.Entity<WorkflowJob>(entity =>
         {
             entity.ToTable("workflow_jobs");
-            entity.Property(job => job.Payload).HasColumnType("jsonb");
+            entity.Property(job => job.Payload).ConfigureJsonDocument(jsonColumnType);
             entity.Property(job => job.LockedBy).HasMaxLength(200);
             entity.Property(job => job.LastError).HasMaxLength(4000);
             entity.HasIndex(job => new { job.Status, job.AvailableAt });
@@ -73,5 +79,78 @@ public sealed class ApplicationDbContext(DbContextOptions<ApplicationDbContext> 
             entity.HasIndex(registration => new { registration.Method, registration.Path });
             entity.HasIndex(registration => registration.WorkflowId);
         });
+
+        if (isSqlite)
+        {
+            builder.ConfigureSqliteDateTimeOffset();
+        }
+    }
+
+    private string GetJsonColumnType() =>
+        Database.ProviderName switch
+        {
+            "Npgsql.EntityFrameworkCore.PostgreSQL" => "jsonb",
+            "Microsoft.EntityFrameworkCore.SqlServer" => "nvarchar(max)",
+            "Microsoft.EntityFrameworkCore.Sqlite" => "TEXT",
+            _ => "jsonb"
+        };
+
+    internal static readonly ValueConverter<JsonDocument, string> JsonDocumentConverter = new(
+        document => document.RootElement.GetRawText(),
+        json => JsonDocument.Parse(string.IsNullOrWhiteSpace(json) ? "{}" : json));
+
+    internal static readonly ValueComparer<JsonDocument> JsonDocumentComparer = new(
+        (left, right) => JsonEquals(left, right),
+        document => document.RootElement.GetRawText().GetHashCode(StringComparison.Ordinal),
+        document => JsonDocument.Parse(document.RootElement.GetRawText()));
+
+    private static bool JsonEquals(JsonDocument? left, JsonDocument? right) =>
+        left is null
+            ? right is null
+            : right is not null && left.RootElement.GetRawText() == right.RootElement.GetRawText();
+
+    internal static readonly ValueConverter<DateTimeOffset, long> DateTimeOffsetToLongConverter = new(
+        value => value.ToUnixTimeMilliseconds(),
+        value => DateTimeOffset.FromUnixTimeMilliseconds(value));
+
+    internal static readonly ValueConverter<DateTimeOffset?, long?> NullableDateTimeOffsetToLongConverter = new(
+        value => value.HasValue ? value.Value.ToUnixTimeMilliseconds() : null,
+        value => value.HasValue ? DateTimeOffset.FromUnixTimeMilliseconds(value.Value) : null);
+}
+
+internal static class JsonDocumentPropertyBuilderExtensions
+{
+    public static void ConfigureJsonDocument(this PropertyBuilder<JsonDocument> property, string columnType)
+    {
+        property.HasColumnType(columnType);
+
+        if (!columnType.Equals("jsonb", StringComparison.OrdinalIgnoreCase))
+        {
+            property.HasConversion(ApplicationDbContext.JsonDocumentConverter);
+            property.Metadata.SetValueComparer(ApplicationDbContext.JsonDocumentComparer);
+        }
+    }
+}
+
+internal static class SqliteDateTimeOffsetModelBuilderExtensions
+{
+    public static void ConfigureSqliteDateTimeOffset(this ModelBuilder builder)
+    {
+        foreach (var entityType in builder.Model.GetEntityTypes())
+        {
+            foreach (var property in entityType.GetProperties())
+            {
+                if (property.ClrType == typeof(DateTimeOffset))
+                {
+                    property.SetValueConverter(ApplicationDbContext.DateTimeOffsetToLongConverter);
+                    property.SetColumnType("INTEGER");
+                }
+                else if (property.ClrType == typeof(DateTimeOffset?))
+                {
+                    property.SetValueConverter(ApplicationDbContext.NullableDateTimeOffsetToLongConverter);
+                    property.SetColumnType("INTEGER");
+                }
+            }
+        }
     }
 }

--- a/src/FlowSharp.Infrastructure/Data/DatabaseMigrationExtensions.cs
+++ b/src/FlowSharp.Infrastructure/Data/DatabaseMigrationExtensions.cs
@@ -13,8 +13,18 @@ public static class DatabaseMigrationExtensions
         var logger = scope.ServiceProvider.GetRequiredService<ILogger<ApplicationDbContext>>();
         var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
-        logger.LogInformation("Applying pending EF Core migrations.");
-        await dbContext.Database.MigrateAsync();
-        logger.LogInformation("EF Core migrations are up to date.");
+        if (dbContext.Database.IsNpgsql())
+        {
+            logger.LogInformation("Applying pending EF Core migrations.");
+            await dbContext.Database.MigrateAsync();
+            logger.LogInformation("EF Core migrations are up to date.");
+            return;
+        }
+
+        logger.LogWarning(
+            "No provider-specific migrations are available for {Provider}. Ensuring database schema exists.",
+            dbContext.Database.ProviderName);
+        await dbContext.Database.EnsureCreatedAsync();
+        logger.LogInformation("Database schema exists.");
     }
 }

--- a/src/FlowSharp.Infrastructure/Data/DatabaseOptions.cs
+++ b/src/FlowSharp.Infrastructure/Data/DatabaseOptions.cs
@@ -1,0 +1,26 @@
+namespace FlowSharp.Infrastructure.Data;
+
+public sealed class DatabaseOptions
+{
+    public const string SectionName = "Database";
+
+    public string Provider { get; set; } = DatabaseProviders.Postgres;
+
+    public bool ApplyMigrationsOnStartup { get; set; } = true;
+}
+
+public static class DatabaseProviders
+{
+    public const string Postgres = "Postgres";
+    public const string SqlServer = "SqlServer";
+    public const string Sqlite = "Sqlite";
+
+    public static string Normalize(string? provider) =>
+        provider?.Trim().ToLowerInvariant() switch
+        {
+            "postgres" or "postgresql" or "npgsql" => Postgres,
+            "sqlserver" or "mssql" or "sql-server" => SqlServer,
+            "sqlite" or "sqlite3" => Sqlite,
+            _ => Postgres
+        };
+}

--- a/src/FlowSharp.Infrastructure/DependencyInjection.cs
+++ b/src/FlowSharp.Infrastructure/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 using FlowSharp.Application.Abstractions;
 using FlowSharp.Application.Nodes;
@@ -23,14 +24,40 @@ public static class DependencyInjection
         var connectionString = configuration.GetConnectionString("DefaultConnection")
             ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
 
-        services.AddDbContext<ApplicationDbContext>(options => options.UseNpgsql(connectionString));
+        services.Configure<DatabaseOptions>(configuration.GetSection(DatabaseOptions.SectionName));
+        var databaseProvider = DatabaseProviders.Normalize(configuration.GetValue<string>("Database:Provider"));
+
+        services.AddDbContext<ApplicationDbContext>(options =>
+        {
+            switch (databaseProvider)
+            {
+                case DatabaseProviders.SqlServer:
+                    options.UseSqlServer(connectionString);
+                    break;
+                case DatabaseProviders.Sqlite:
+                    options.UseSqlite(connectionString);
+                    break;
+                default:
+                    options.UseNpgsql(connectionString);
+                    break;
+            }
+        });
         services.Configure<HttpNodeNetworkOptions>(configuration.GetSection(HttpNodeNetworkOptions.SectionName));
         services.AddTransient<PrivateNetworkBlockingHandler>();
         services.AddHttpClient("workflow-nodes")
             .AddHttpMessageHandler<PrivateNetworkBlockingHandler>();
 
         // Kuyruk ve calistirma
-        services.AddScoped<IWorkflowQueue, PostgresWorkflowQueue>();
+        services.AddScoped<IWorkflowQueue>(sp =>
+        {
+            var provider = DatabaseProviders.Normalize(sp.GetRequiredService<IOptions<DatabaseOptions>>().Value.Provider);
+            return provider switch
+            {
+                DatabaseProviders.SqlServer => ActivatorUtilities.CreateInstance<SqlServerWorkflowQueue>(sp),
+                DatabaseProviders.Sqlite => ActivatorUtilities.CreateInstance<SqliteWorkflowQueue>(sp),
+                _ => ActivatorUtilities.CreateInstance<PostgresWorkflowQueue>(sp)
+            };
+        });
         services.AddScoped<IWorkflowRunner, WorkflowRunner>();
         services.Configure<Application.Workflows.ExecutionOptions>(
             configuration.GetSection(Application.Workflows.ExecutionOptions.SectionName));

--- a/src/FlowSharp.Infrastructure/FlowSharp.Infrastructure.csproj
+++ b/src/FlowSharp.Infrastructure/FlowSharp.Infrastructure.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.77.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageReference Include="StackExchange.Redis" Version="2.13.17" />

--- a/src/FlowSharp.Infrastructure/Queue/EfWorkflowQueue.cs
+++ b/src/FlowSharp.Infrastructure/Queue/EfWorkflowQueue.cs
@@ -1,0 +1,92 @@
+using System.Data;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using FlowSharp.Application.Abstractions;
+using FlowSharp.Domain.Queue;
+using FlowSharp.Infrastructure.Data;
+
+namespace FlowSharp.Infrastructure.Queue;
+
+public abstract class EfWorkflowQueue(ApplicationDbContext dbContext) : IWorkflowQueue
+{
+    protected ApplicationDbContext DbContext { get; } = dbContext;
+
+    protected virtual IsolationLevel DequeueIsolationLevel => IsolationLevel.ReadCommitted;
+
+    public async Task<WorkflowJob> EnqueueAsync(Guid workflowId, JsonDocument payload, CancellationToken cancellationToken = default)
+    {
+        var job = new WorkflowJob
+        {
+            WorkflowId = workflowId,
+            Payload = payload
+        };
+
+        DbContext.WorkflowJobs.Add(job);
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return job;
+    }
+
+    public virtual async Task<WorkflowJob?> DequeueAsync(string workerId, TimeSpan lockDuration, CancellationToken cancellationToken = default)
+    {
+        await using var transaction = await DbContext.Database.BeginTransactionAsync(DequeueIsolationLevel, cancellationToken);
+        var now = DateTimeOffset.UtcNow;
+
+        var job = await DbContext.WorkflowJobs
+            .Where(job => job.Status == WorkflowJobStatus.Pending)
+            .Where(job => job.AvailableAt <= now)
+            .OrderBy(job => job.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (job is null)
+        {
+            await transaction.CommitAsync(cancellationToken);
+            return null;
+        }
+
+        job.Status = WorkflowJobStatus.Processing;
+        job.LockedBy = workerId;
+        job.LockedUntil = now.Add(lockDuration);
+        job.AttemptCount++;
+        job.UpdatedAt = now;
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+
+        return job;
+    }
+
+    public async Task CompleteAsync(Guid jobId, CancellationToken cancellationToken = default)
+    {
+        var job = await DbContext.WorkflowJobs.FindAsync([jobId], cancellationToken);
+        if (job is null)
+        {
+            return;
+        }
+
+        job.Status = WorkflowJobStatus.Completed;
+        job.LockedBy = null;
+        job.LockedUntil = null;
+        job.UpdatedAt = DateTimeOffset.UtcNow;
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task FailAsync(Guid jobId, string error, CancellationToken cancellationToken = default)
+    {
+        var job = await DbContext.WorkflowJobs.FindAsync([jobId], cancellationToken);
+        if (job is null)
+        {
+            return;
+        }
+
+        job.LastError = error;
+        job.LockedBy = null;
+        job.LockedUntil = null;
+        job.UpdatedAt = DateTimeOffset.UtcNow;
+        job.Status = job.AttemptCount >= job.MaxAttempts ? WorkflowJobStatus.DeadLetter : WorkflowJobStatus.Pending;
+        job.AvailableAt = DateTimeOffset.UtcNow.AddSeconds(Math.Min(300, Math.Pow(2, job.AttemptCount) * 5));
+
+        await DbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/FlowSharp.Infrastructure/Queue/PostgresWorkflowQueue.cs
+++ b/src/FlowSharp.Infrastructure/Queue/PostgresWorkflowQueue.cs
@@ -1,84 +1,9 @@
-using System.Text.Json;
-using Microsoft.EntityFrameworkCore;
-using FlowSharp.Application.Abstractions;
-using FlowSharp.Domain.Queue;
+using System.Data;
 using FlowSharp.Infrastructure.Data;
 
 namespace FlowSharp.Infrastructure.Queue;
 
-public sealed class PostgresWorkflowQueue(ApplicationDbContext dbContext) : IWorkflowQueue
+public sealed class PostgresWorkflowQueue(ApplicationDbContext dbContext) : EfWorkflowQueue(dbContext)
 {
-    public async Task<WorkflowJob> EnqueueAsync(Guid workflowId, JsonDocument payload, CancellationToken cancellationToken = default)
-    {
-        var job = new WorkflowJob
-        {
-            WorkflowId = workflowId,
-            Payload = payload
-        };
-
-        dbContext.WorkflowJobs.Add(job);
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        return job;
-    }
-
-    public async Task<WorkflowJob?> DequeueAsync(string workerId, TimeSpan lockDuration, CancellationToken cancellationToken = default)
-    {
-        var now = DateTimeOffset.UtcNow;
-
-        var job = await dbContext.WorkflowJobs
-            .Where(job => job.Status == WorkflowJobStatus.Pending)
-            .Where(job => job.AvailableAt <= now)
-            .OrderBy(job => job.CreatedAt)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (job is null)
-        {
-            return null;
-        }
-
-        job.Status = WorkflowJobStatus.Processing;
-        job.LockedBy = workerId;
-        job.LockedUntil = now.Add(lockDuration);
-        job.AttemptCount++;
-        job.UpdatedAt = now;
-
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        return job;
-    }
-
-    public async Task CompleteAsync(Guid jobId, CancellationToken cancellationToken = default)
-    {
-        var job = await dbContext.WorkflowJobs.FindAsync([jobId], cancellationToken);
-        if (job is null)
-        {
-            return;
-        }
-
-        job.Status = WorkflowJobStatus.Completed;
-        job.LockedBy = null;
-        job.LockedUntil = null;
-        job.UpdatedAt = DateTimeOffset.UtcNow;
-
-        await dbContext.SaveChangesAsync(cancellationToken);
-    }
-
-    public async Task FailAsync(Guid jobId, string error, CancellationToken cancellationToken = default)
-    {
-        var job = await dbContext.WorkflowJobs.FindAsync([jobId], cancellationToken);
-        if (job is null)
-        {
-            return;
-        }
-
-        job.LastError = error;
-        job.LockedBy = null;
-        job.LockedUntil = null;
-        job.UpdatedAt = DateTimeOffset.UtcNow;
-        job.Status = job.AttemptCount >= job.MaxAttempts ? WorkflowJobStatus.DeadLetter : WorkflowJobStatus.Pending;
-        job.AvailableAt = DateTimeOffset.UtcNow.AddSeconds(Math.Min(300, Math.Pow(2, job.AttemptCount) * 5));
-
-        await dbContext.SaveChangesAsync(cancellationToken);
-    }
+    protected override IsolationLevel DequeueIsolationLevel => IsolationLevel.ReadCommitted;
 }

--- a/src/FlowSharp.Infrastructure/Queue/SqlServerWorkflowQueue.cs
+++ b/src/FlowSharp.Infrastructure/Queue/SqlServerWorkflowQueue.cs
@@ -1,0 +1,9 @@
+using System.Data;
+using FlowSharp.Infrastructure.Data;
+
+namespace FlowSharp.Infrastructure.Queue;
+
+public sealed class SqlServerWorkflowQueue(ApplicationDbContext dbContext) : EfWorkflowQueue(dbContext)
+{
+    protected override IsolationLevel DequeueIsolationLevel => IsolationLevel.Serializable;
+}

--- a/src/FlowSharp.Infrastructure/Queue/SqliteWorkflowQueue.cs
+++ b/src/FlowSharp.Infrastructure/Queue/SqliteWorkflowQueue.cs
@@ -1,0 +1,9 @@
+using System.Data;
+using FlowSharp.Infrastructure.Data;
+
+namespace FlowSharp.Infrastructure.Queue;
+
+public sealed class SqliteWorkflowQueue(ApplicationDbContext dbContext) : EfWorkflowQueue(dbContext)
+{
+    protected override IsolationLevel DequeueIsolationLevel => IsolationLevel.Serializable;
+}

--- a/src/FlowSharp.Web/appsettings.json
+++ b/src/FlowSharp.Web/appsettings.json
@@ -1,8 +1,9 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=FlowSharpDb;Username=postgres;Password=postgres"
+    "DefaultConnection": "Data Source=App_Data/flowsharp.db"
   },
   "Database": {
+    "Provider": "Sqlite",
     "ApplyMigrationsOnStartup": true
   },
   "Redis": {

--- a/src/FlowSharp.Worker/appsettings.json
+++ b/src/FlowSharp.Worker/appsettings.json
@@ -1,8 +1,9 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=FlowSharpDb;Username=postgres;Password=postgres"
+    "DefaultConnection": "Data Source=App_Data/flowsharp.db"
   },
   "Database": {
+    "Provider": "Sqlite",
     "ApplyMigrationsOnStartup": true
   },
   "Redis": {


### PR DESCRIPTION
Revamp docs and README (EN + TR) for a leaner quick-start and add Built-in Nodes guide. Switch Docker Compose to use SQLite by default (Database__Provider=Sqlite, shared App_Data volume) and update appsettings examples. Introduce DatabaseOptions and add/modify EF Core queue implementations (EF, Postgres, SQL Server, SQLite), adjust DI and database migration extension code, and update project appsettings for web and worker. These changes enable SQLite local dev mode, clarify supported DB providers, and surface built-in node documentation.